### PR TITLE
Extract instructions for Package Control out of Sublime Text preferences

### DIFF
--- a/OSX.md
+++ b/OSX.md
@@ -57,9 +57,10 @@ We will install the package manager right away, you'll need this to install addo
 
 If you have trouble with this step, ask a teacher. This was the only time we use the sublime text prompt. All other commands will be in the Terminal.
 
-To check that the Package Control is installed, you can hit `⌘`+`⇧`+`P` (`Ctrl`+`⇧`+`P` on Ubuntu), and type `installp`. If you see something like below, you're good to go!
+To check that the Package Control is installed, you can hit `⌘`+`⇧`+`P`, and type `installp`. If you see something like below, you're good to go!
 
 ![](images/sublime-install-package.png)
+
 
 ### Useful Packages
 

--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -61,13 +61,14 @@ Sublime Text is free without any time limitation but a popup will appear every t
 
 ### Package control
 
-We will install the package manager right away, you'll need this to install addons. Launch Sublime Text, and open the console via the `View > Show Console` menu. This will show a prompt at the bottom of Sublime Text window where you can type stuff. You need to [copy some code](https://sublime.wbond.net/installation#st2) and paste it in that Sublime Text console. Then hit `Enter`. Restart Sublime Text (`⌘` + `Q` is a handy shortcut to quit an application on OS X, the red dot in the top left corner of the window does **not** quit an application).
+We will install the package manager right away, you'll need this to install addons. Launch Sublime Text, and open the console via the `View > Show Console` menu. This will show a prompt at the bottom of Sublime Text window where you can type stuff. You need to [copy some code](https://sublime.wbond.net/installation#st2) and paste it in that Sublime Text console. Then hit `Enter`. Restart Sublime Text (`Ctrl` + `q` is a handy shortcut to quit the application since the close button in top corner of the window will only close the current window and **not** quit Sublime Text).
 
 If you have trouble with this step, ask a teacher. This was the only time we use the sublime text prompt. All other commands will be in the Terminal.
 
-To check that the Package Control is installed, you can hit `⌘`+`⇧`+`P` (`Ctrl`+`⇧`+`P` on Ubuntu), and type `installp`. If you see something like below, you're good to go!
+To check that the Package Control is installed, you can hit `Ctrl`+`⇧`+`P`, and type `installp`. If you see something like below, you're good to go!
 
 ![](images/sublime-install-package.png)
+
 
 ### Useful Packages
 

--- a/_partials/osx_sublime_text_package_control.md
+++ b/_partials/osx_sublime_text_package_control.md
@@ -1,0 +1,9 @@
+### Package control
+
+We will install the package manager right away, you'll need this to install addons. Launch Sublime Text, and open the console via the `View > Show Console` menu. This will show a prompt at the bottom of Sublime Text window where you can type stuff. You need to [copy some code](https://sublime.wbond.net/installation#st2) and paste it in that Sublime Text console. Then hit `Enter`. Restart Sublime Text (`⌘` + `Q` is a handy shortcut to quit an application on OS X, the red dot in the top left corner of the window does **not** quit an application).
+
+If you have trouble with this step, ask a teacher. This was the only time we use the sublime text prompt. All other commands will be in the Terminal.
+
+To check that the Package Control is installed, you can hit `⌘`+`⇧`+`P`, and type `installp`. If you see something like below, you're good to go!
+
+![](images/sublime-install-package.png)

--- a/_partials/sublime_text_preferences.md
+++ b/_partials/sublime_text_preferences.md
@@ -1,13 +1,3 @@
-### Package control
-
-We will install the package manager right away, you'll need this to install addons. Launch Sublime Text, and open the console via the `View > Show Console` menu. This will show a prompt at the bottom of Sublime Text window where you can type stuff. You need to [copy some code](https://sublime.wbond.net/installation#st2) and paste it in that Sublime Text console. Then hit `Enter`. Restart Sublime Text (`⌘` + `Q` is a handy shortcut to quit an application on OS X, the red dot in the top left corner of the window does **not** quit an application).
-
-If you have trouble with this step, ask a teacher. This was the only time we use the sublime text prompt. All other commands will be in the Terminal.
-
-To check that the Package Control is installed, you can hit `⌘`+`⇧`+`P` (`Ctrl`+`⇧`+`P` on Ubuntu), and type `installp`. If you see something like below, you're good to go!
-
-![](images/sublime-install-package.png)
-
 ### Useful Packages
 
 Here is a list of packages you should install to harness the power of Sublime Text with Ruby, Rails and Middleman:

--- a/_partials/ubuntu_sublime_text_package_control.md
+++ b/_partials/ubuntu_sublime_text_package_control.md
@@ -1,0 +1,9 @@
+### Package control
+
+We will install the package manager right away, you'll need this to install addons. Launch Sublime Text, and open the console via the `View > Show Console` menu. This will show a prompt at the bottom of Sublime Text window where you can type stuff. You need to [copy some code](https://sublime.wbond.net/installation#st2) and paste it in that Sublime Text console. Then hit `Enter`. Restart Sublime Text (`Ctrl` + `q` is a handy shortcut to quit the application since the close button in top corner of the window will only close the current window and **not** quit Sublime Text).
+
+If you have trouble with this step, ask a teacher. This was the only time we use the sublime text prompt. All other commands will be in the Terminal.
+
+To check that the Package Control is installed, you can hit `Ctrl`+`⇧`+`P`, and type `installp`. If you see something like below, you're good to go!
+
+![](images/sublime-install-package.png)

--- a/build.rb
+++ b/build.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby -wU
 
-OSX = %w(intro github osx_command_line_tools osx_sublime_text sublime_text_preferences homebrew  osx_oh_my_zsh github_rsa dotfiles rbenv rbenv_ruby osx_security checkup alumni_platform osx_slack)
-UBUNTU = %w(intro ubuntu_virtualbox github ubuntu_sublime_text sublime_text_preferences ubuntu_git ubuntu_oh_my_zsh github_rsa dotfiles rbenv rbenv_ubuntu rbenv_ruby checkup alumni_platform)
+OSX = %w(intro github osx_command_line_tools osx_sublime_text osx_sublime_text_package_control sublime_text_preferences homebrew  osx_oh_my_zsh github_rsa dotfiles rbenv rbenv_ruby osx_security checkup alumni_platform osx_slack)
+UBUNTU = %w(intro ubuntu_virtualbox github ubuntu_sublime_text ubuntu_sublime_text_package_control sublime_text_preferences ubuntu_git ubuntu_oh_my_zsh github_rsa dotfiles rbenv rbenv_ubuntu rbenv_ruby checkup alumni_platform)
 
 { 'OSX.md': OSX, 'UBUNTU.md': UBUNTU }.each do |filename, partials|
   File.open(filename.to_s, 'w') do |f|


### PR DESCRIPTION
- Split Package Control instructions in 2 versions: OSX & Ubuntu