### PR TITLE
Simplify OS X setup

### DIFF
--- a/OSX.md
+++ b/OSX.md
@@ -280,9 +280,7 @@ an open-source robust and production-ready database. Let's install it now.
 ```bash
 brew update
 brew install postgresql
-mkdir -p ~/Library/LaunchAgents
-ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
-launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
+brew services start postgresql
 ```
 
 Once you've done that, let's check if it worked:

--- a/OSX.md
+++ b/OSX.md
@@ -131,12 +131,11 @@ mkdir -p ~/.ssh && ssh-keygen -t rsa -C "your_email@example.com"
 Then you need to give your **public** key to GitHub. Run:
 
 ```bash
-cat ~/.ssh/id_rsa.pub
+cat ~/.ssh/id_rsa.pub | pbcopy
 ```
 
-It will prompt on the screen the content of the `id_rsa.pub` file. Copy that text,
-then go to [github.com/settings/ssh](https://github.com/settings/ssh). Click on
-**Add SSH key**, fill in the Title with your computer name, and paste the **Key**.
+Now go to [github.com/settings/ssh](https://github.com/settings/ssh). Click on
+**Add SSH key**, fill in the Title with your computer name, and paste (CMD-V) the **Key**.
 Finish by clicking on the **Add key** green button.
 
 To check that this step is completed, in the terminal run this. You will be


### PR DESCRIPTION
- Using pbcopy to skip having to manually copy the SSH key into the clipboard.
- Using `brew services` to install Postgres as a service