### PR TITLE
Update rbenv_osx.md for Pygments error

### DIFF
--- a/_partials/rbenv_osx.md
+++ b/_partials/rbenv_osx.md
@@ -17,3 +17,6 @@ brew uninstall --force rbenv ruby-build
 unset RBENV_ROOT && source ~/.zshrc
 brew install rbenv ruby-build && source ~/.zshrc
 ```
+If you got an error with `Pygments`, install `Pygments` with the following command :
+```bash
+sudo easy_install Pygments```

--- a/_partials/rbenv_osx.md
+++ b/_partials/rbenv_osx.md
@@ -17,6 +17,8 @@ brew uninstall --force rbenv ruby-build
 unset RBENV_ROOT && source ~/.zshrc
 brew install rbenv ruby-build && source ~/.zshrc
 ```
-If you got an error with `Pygments`, install `Pygments` with the following command :
+If you got an error with `Pygments`, install `Pygments` with the following command:
+
 ```bash
-sudo easy_install Pygments```
+sudo easy_install Pygments
+```


### PR DESCRIPTION
Sometimes your computer require Pygments when you run the following command:
unset RBENV_ROOT && source ~/.zshrc

So I add the command line to install it.