### PR TITLE
remove necessity to publish email address

### DIFF
--- a/OSX.md
+++ b/OSX.md
@@ -40,11 +40,6 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 👉 **[Upload a picture](https://github.com/settings/profile)** and put your name correctly on your GitHub account. This is important as we'll use an internal dashboard with your avatars. Please do it **now**.
 
-👉 Then go to your [GitHub Profile](https://github.com/settings/admin) and publicize your email address.
-That should not say `Don't show my email address`. Don't forget to click on the green `Update Profile` button.
-
-![](images/github_public_email.gif)
-
 
 ## Homebrew
 

--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -15,11 +15,6 @@ Have you signed up to GitHub? If not, [do it right away](https://github.com/join
 
 👉 **[Upload a picture](https://github.com/settings/profile)** and put your name correctly on your GitHub account. This is important as we'll use an internal dashboard with your avatars. Please do it **now**.
 
-👉 Then go to your [GitHub Profile](https://github.com/settings/admin) and publicize your email address.
-That should not say `Don't show my email address`. Don't forget to click on the green `Update Profile` button.
-
-![](images/github_public_email.gif)
-
 
 ## Sublime Text 3 - Your text editor
 

--- a/check.rb
+++ b/check.rb
@@ -52,20 +52,15 @@ def check_all
     begin
       token = File.read("#{ENV['HOME']}/.gist")
       groups = `ssh -T git@github.com 2>&1`.match(/Hi (?<nickname>.*)! You've successfully authenticated/)
-      git_email = (`git config --global user.email`).chomp
 
       if groups && (nickname = groups["nickname"])
         github_user = JSON.parse(open("https://api.github.com/users/#{nickname}?access_token=#{token}").read)
         if github_user["name"] != nickname && !github_user["name"].nil? || github_user["name"] != ""
-          if github_user["email"] == git_email
-            content_length = `curl -s -I #{github_user["avatar_url"]} | grep 'Content-Length:'`.strip.gsub("Content-Length: ", "").to_i
-            if content_length >= MINIMUM_AVATAR_SIZE
-              [ true, "Seems ok. Your GitHub username is #{nickname} and you have a profile picture"]
-            else
-              [ false, "Your GitHub username appears to be #{nickname} (correct?), but you don't have any profile picture set.\nIt's important, go to github.com/settings/profile and upload a picture right now."]
-            end
+          content_length = `curl -s -I #{github_user["avatar_url"]} | grep 'Content-Length:'`.strip.gsub("Content-Length: ", "").to_i
+          if content_length >= MINIMUM_AVATAR_SIZE
+            [ true, "Seems ok. Your GitHub username is #{nickname} and you have a profile picture"]
           else
-            [ false, "Your GitHub email is '#{github_user["email"]}' whereas your git email is '#{git_email}'. Please run\n\n  git config --global user.email #{github_user["email"]}"]
+            [ false, "Your GitHub username appears to be #{nickname} (correct?), but you don't have any profile picture set.\nIt's important, go to github.com/settings/profile and upload a picture right now."]
           end
         else
           [ false, "Please specify your first and last name on your GitHub account -> https://github.com/settings/profile"]

--- a/check.rb
+++ b/check.rb
@@ -11,7 +11,7 @@ require "open-uri"
 
 REQUIRED_RUBY_VERSION = "2.3.4"
 REQUIRED_GIT_VERSION = "2.0"
-VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
+#VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
 MINIMUM_AVATAR_SIZE = 2 * 1024
 
 $all_good = true


### PR DESCRIPTION
The necessity to publish your email address may put students at risk.

Some may not be aware of the scope that publishing your email address on github entails, and the potential abuse that goes with it.

Please be considerate in regards to the safety of your students.