### PR TITLE
Remove mention of Astrill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### In China?
 
-Before starting the setup :point_down: you will get VPN codes for Astrill from your city manager.
+Before starting the setup :point_down: you want to turn on your VPN, or get VPN codes from your city manager right away.
 
 ### Worldwide
 


### PR DESCRIPTION
Astrill VPN is used in Shanghai only, other CN cities use different VPN providers.
Also, a large number of students already have their own solution installed.