### PR TITLE
simplified ubuntu postgres setup

### DIFF
--- a/_partials/ubuntu_postgresql.md
+++ b/_partials/ubuntu_postgresql.md
@@ -4,10 +4,6 @@ In a few weeks, we'll talk about SQL and Databases and you'll need something cal
 an open-source robust and production-ready database. Let's install it now.
 
 ```
-sudo apt-get install -y postgresql postgresql-contrib libpq-dev build-essential
-echo `whoami` > /tmp/caller
-sudo su - postgres
-psql --command "CREATE ROLE `cat /tmp/caller` LOGIN createdb;"
-exit
-rm -f /tmp/caller
+sudo apt install -y postgresql postgresql-contrib libpq-dev build-essential
+sudo -u postgres psql --command "CREATE ROLE `whoami` LOGIN createdb;"
 ```

--- a/_partials/wls_postgresql.md
+++ b/_partials/wls_postgresql.md
@@ -4,13 +4,9 @@ In a few weeks, we'll talk about SQL and Databases and you'll need something cal
 an open-source robust and production-ready database. Let's install it now.
 
 ```
-sudo apt-get install -y postgresql postgresql-contrib libpq-dev build-essential
+sudo apt install -y postgresql postgresql-contrib libpq-dev build-essential
 sudo /etc/init.d/postgresql start
-echo `whoami` > /tmp/caller
-sudo su - postgres
-psql --command "CREATE ROLE `cat /tmp/caller` LOGIN createdb;"
-exit
-rm -f /tmp/caller
+sudo -u postgres psql --command "CREATE ROLE `whoami` LOGIN createdb;"
 ```
 
 The Linux subsystem is missing some parts that start services automatically when the system boots up. To configure this, you need to add those start-up lines manually to the file `/etc/rc.local`.


### PR DESCRIPTION
move from apt-get to apt because computers are horrible, and shrink commands required.