### PR TITLE
Update screencapture location for Mojave

### DIFF
--- a/macOS.md
+++ b/macOS.md
@@ -452,7 +452,7 @@ defaults write NSGlobalDomain PMPrintingExpandedStateForPrint -bool true
 defaults write NSGlobalDomain PMPrintingExpandedStateForPrint2 -bool true
 
 # Save screenshots to the Desktop (or elsewhere)
-defaults write com.apple.screencapture location -string "${HOME}/Desktop"
+defaults write com.apple.screencapture location ${HOME}/Desktop
 
 # etc..
 ```


### PR DESCRIPTION
For some reason on the new macOS the `-string` have no effect 