### PR TITLE
Update OSX.md

### DIFF
--- a/second-setup/OSX.md
+++ b/second-setup/OSX.md
@@ -59,6 +59,23 @@ zsh install.sh
 
 ## Ruby
 
+Remove RVM if installed, otherwise continue to **'Using RBENV to install Ruby'** (run *`rvm -v`* to check if it's installed)
+
+```bash
+rvm implode
+gem uninstall rvm  # just in case there was rmv gem installed
+```
+
+Before continuing, make sure there is no RVM files remaining in your root drive.
+
+```bash
+cd && ls -la
+rm -rf .rvm    # if the file exists
+rm -rf .rvmrc  # ditto
+```
+
+#### Using RBENV to install Ruby
+
 ```bash
 sudo rm -rf $HOME/.rbenv /usr/local/rbenv /opt/rbenv /usr/local/opt/rbenv
 brew uninstall --force rbenv ruby-build


### PR DESCRIPTION
I routinely ran into issues getting the right version of ruby to be 'seen' using RBENV, and as a beginner I was not aware of when, who, why, how, where RVM was installed. Nor was I aware how and why having RVM and RBENV installed simultaneously would pose an issue. So having this extra step to clear RVM in the event it is installed will save a lot of nubies hours of googling and frustration. - Or an argument could be made that I am just an imbecile