### PR TITLE
bump Ruby to 2.6.3

### DIFF
--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -224,14 +224,14 @@ Now, you are ready to install the latest ruby version, and set it as the default
 Run this command, it will **take a while (5-10 minutes)**
 
 ```bash
-rbenv install 2.5.3
+rbenv install 2.6.3
 ```
 
 Once the ruby installation is done, run this command to tell the system
-to use the 2.5.3 version by default.
+to use the 2.6.3 version by default.
 
 ```bash
-rbenv global 2.5.3
+rbenv global 2.6.3
 ```
 
 Then **restart** your Terminal again (close it and reopen it).
@@ -240,7 +240,7 @@ Then **restart** your Terminal again (close it and reopen it).
 ruby -v
 ```
 
-You should see something starting with `ruby 2.5.3p`. If not, ask a teacher.
+You should see something starting with `ruby 2.6.3p`. If not, ask a teacher.
 
 ## Installing some gems
 

--- a/WINDOWS_LINUX_SUBSYSTEM.md
+++ b/WINDOWS_LINUX_SUBSYSTEM.md
@@ -296,14 +296,14 @@ Now, you are ready to install the latest ruby version, and set it as the default
 Run this command, it will **take a while (5-10 minutes)**
 
 ```bash
-rbenv install 2.5.3
+rbenv install 2.6.3
 ```
 
 Once the ruby installation is done, run this command to tell the system
-to use the 2.5.3 version by default.
+to use the 2.6.3 version by default.
 
 ```bash
-rbenv global 2.5.3
+rbenv global 2.6.3
 ```
 
 Then **restart** your Terminal again (close it and reopen it).
@@ -312,7 +312,7 @@ Then **restart** your Terminal again (close it and reopen it).
 ruby -v
 ```
 
-You should see something starting with `ruby 2.5.3p`. If not, ask a teacher.
+You should see something starting with `ruby 2.6.3p`. If not, ask a teacher.
 
 ## Installing some gems
 

--- a/_partials/rbenv_ruby.md
+++ b/_partials/rbenv_ruby.md
@@ -3,14 +3,14 @@ Now, you are ready to install the latest ruby version, and set it as the default
 Run this command, it will **take a while (5-10 minutes)**
 
 ```bash
-rbenv install 2.5.3
+rbenv install 2.6.3
 ```
 
 Once the ruby installation is done, run this command to tell the system
-to use the 2.5.3 version by default.
+to use the 2.6.3 version by default.
 
 ```bash
-rbenv global 2.5.3
+rbenv global 2.6.3
 ```
 
 Then **restart** your Terminal again (close it and reopen it).
@@ -19,7 +19,7 @@ Then **restart** your Terminal again (close it and reopen it).
 ruby -v
 ```
 
-You should see something starting with `ruby 2.5.3p`. If not, ask a teacher.
+You should see something starting with `ruby 2.6.3p`. If not, ask a teacher.
 
 ## Installing some gems
 

--- a/check.rb
+++ b/check.rb
@@ -10,7 +10,7 @@ end
 require "json"
 require "open-uri"
 
-REQUIRED_RUBY_VERSION = "2.5.3"
+REQUIRED_RUBY_VERSION = "2.6.3"
 REQUIRED_GIT_VERSION = "2.0"
 MINIMUM_AVATAR_SIZE = 2 * 1024
 GITHUB_AUTHORIZATION_NOTE = 'Le Wagon setup check'.freeze

--- a/macOS.md
+++ b/macOS.md
@@ -303,14 +303,14 @@ Now, you are ready to install the latest ruby version, and set it as the default
 Run this command, it will **take a while (5-10 minutes)**
 
 ```bash
-rbenv install 2.5.3
+rbenv install 2.6.3
 ```
 
 Once the ruby installation is done, run this command to tell the system
-to use the 2.5.3 version by default.
+to use the 2.6.3 version by default.
 
 ```bash
-rbenv global 2.5.3
+rbenv global 2.6.3
 ```
 
 Then **restart** your Terminal again (close it and reopen it).
@@ -319,7 +319,7 @@ Then **restart** your Terminal again (close it and reopen it).
 ruby -v
 ```
 
-You should see something starting with `ruby 2.5.3p`. If not, ask a teacher.
+You should see something starting with `ruby 2.6.3p`. If not, ask a teacher.
 
 ## Installing some gems
 

--- a/second-setup/OSX.md
+++ b/second-setup/OSX.md
@@ -64,8 +64,8 @@ sudo rm -rf $HOME/.rbenv /usr/local/rbenv /opt/rbenv /usr/local/opt/rbenv
 brew uninstall --force rbenv ruby-build
 unset RBENV_ROOT && exec zsh
 brew install rbenv ruby-build && exec zsh
-rbenv install 2.5.3
-rbenv global 2.5.3
+rbenv install 2.6.3
+rbenv global 2.6.3
 ```
 
 (`⌘` + `Q`) your terminal and restart it. Check your ruby version with:


### PR DESCRIPTION
This closes #103 by bumping Ruby Wagon-wide to 2.6.3
Glovebox runtime is already updated to run all rakes with 2.6.3