### PR TITLE
Add restart terminal comment

### DIFF
--- a/second-setup/OSX.md
+++ b/second-setup/OSX.md
@@ -79,7 +79,7 @@ ruby -v
 gem install rake bundler rspec rubocop pry pry-byebug hub colored octokit rails
 ```
 
-Check our rails version with:
+(`⌘` + `Q`) your terminal and restart it. Check our rails version with:
 
 ```bash
 rails -v


### PR DESCRIPTION
I spent way longer than I'd care to admit, wondering why Rails wasn't installed, before I realised that I needed to restart terminal again.

Adding this comment might save someone else some time in the future.