### PR TITLE
Update homebrew install

### DIFF
--- a/_partials/homebrew.md
+++ b/_partials/homebrew.md
@@ -5,7 +5,7 @@ It will be used as soon as we need to install some software.
 To do so, open your Terminal and run:
 
 ```bash
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
 This will ask for your confirmation (hit `Enter`) and your laptop session password.

--- a/macOS.md
+++ b/macOS.md
@@ -48,7 +48,7 @@ It will be used as soon as we need to install some software.
 To do so, open your Terminal and run:
 
 ```bash
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
 This will ask for your confirmation (hit `Enter`) and your laptop session password.


### PR DESCRIPTION
Installing command of the homebrew is now with bash!
`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`
https://brew.sh/
(PR: https://github.com/Homebrew/install/pull/256)

That's because the macOS won't include scripting language runtimes by default.

```
Scripting Language Runtimes
Deprecations
Scripting language runtimes such as Python, Ruby, and Perl are included in macOS for compatibility with legacy software. Future versions of macOS won't include scripting language runtimes by default, and might require you to install additional packages. If your software depends on scripting languages, it's recommended that you bundle the runtime within the app. (49764202)
```
https://developer.apple.com/documentation/macos_release_notes/macos_catalina_10_15_release_notes

Slack: https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1583203196106000