### PR TITLE
make it explicit that we need to open an Ubuntu terminal

### DIFF
--- a/_partials/wsl2_git.md
+++ b/_partials/wsl2_git.md
@@ -1,9 +1,8 @@
 ## Git
 
-To install `git`, first open a terminal. To open a terminal, hit **Start** and type **windows terminal** and click on **Windows Terminal (Preview)**.
+To install `git`, first open an Ubuntu terminal. To open an Ubuntu terminal, hit **Start**, type **windows terminal**, and click on **Windows Terminal (Preview)**, then open an **Ubuntu** tab via the drop-down menu next to the already open Windows Powershell tab.
 
-Then copy **line by line** (this will help you identify which line fails if needed :thumbsup:):
-You can paste by doing a right click in the terminal.
+Then copy and paste the following lines **one line at a time** (Note that you can paste by doing a right click in the terminal):
 
 ```bash
 sudo apt update


### PR DESCRIPTION
Almost all students tried to run `sudo apt install` in Powershell, so making it explicit that the Ubuntu terminal is needed, is needed.

I also changed the wording of how to paste, as the explanation is not 100% correct, and some where confused if "You can paste by doing a right click in the terminal." was the thing to be pasted.