### PR TITLE
add a change directory before first stt

### DIFF
--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -211,6 +211,7 @@ Please now **quit** all your opened terminal windows.
 Open a new terminal and type this:
 
 ```bash
+cd ~/code
 stt
 ```
 

--- a/_partials/dotfiles.md
+++ b/_partials/dotfiles.md
@@ -51,6 +51,7 @@ Please now **quit** all your opened terminal windows.
 Open a new terminal and type this:
 
 ```bash
+cd ~/code
 stt
 ```
 

--- a/macOS.md
+++ b/macOS.md
@@ -261,6 +261,7 @@ Please now **quit** all your opened terminal windows.
 Open a new terminal and type this:
 
 ```bash
+cd ~/code
 stt
 ```
 


### PR DESCRIPTION
Change directory before first `stt` to avoid indexing all files
Fix #157 