### PR TITLE
Macos command line tools partial: update the software update catalog 🐛

### DIFF
--- a/_partials/osx_command_line_tools.md
+++ b/_partials/osx_command_line_tools.md
@@ -18,7 +18,7 @@ Copy-paste the following command in the terminal and hit Enter.
 xcode-select --install
 ```
 
-If you'll receive the following message, you can just skip this step and go to next step.
+If you receive the following message, you can just skip this step and go to next step.
 
 ```
 # command line tools are already installed, use "Software Update" to install updates
@@ -29,3 +29,23 @@ Otherwise, it will open a window asking you if you want to install some software
 ![](images/xcode-select-install.png)
 
 While it's downloading, you can go on with configuring your GitHub account, but **stop** before Homebrew. You'll need the command line tools installed for that step.
+
+If you receive the following message, you need to update the sofware update catalog.
+
+```
+Xcode is not currently available from the Software Update server
+```
+
+In this case, copy-paste the following command in the terminal and hit Enter.
+
+```bash
+sudo softwareupdate --clear-catalog
+```
+
+Once this is done, you can try to install again (copy-paste the following command and hit enter).
+
+```bash
+xcode-select --install
+```
+
+Then follow the previous instructions for this command.

--- a/build.rb
+++ b/build.rb
@@ -2,9 +2,65 @@
 
 SETUP_RUBY_VERSION = "2.6.6"
 
-MAC_OS = %w[intro remote_tools osx_command_line_tools github homebrew osx_sublime_text osx_oh_my_zsh github_rsa dotfiles ssh_osx rbenv_osx rbenv_ruby osx_postgresql osx_security checkup alumni_platform osx_slack osx_preferences].freeze
-UBUNTU = %w[intro remote_tools github ubuntu_git ubuntu_sublime_text ubuntu_oh_my_zsh github_rsa dotfiles rbenv_ubuntu rbenv_ruby ubuntu_postgresql ubuntu_inotify ubuntu_extra checkup alumni_platform ubuntu_slack].freeze
-WINDOWS = %w[intro wsl2_prereq_intro wsl2_prereq_win10 wsl2_prereq_win_version wsl2_prereq_virtualization github remote_tools wsl2_install_wsl wsl2_vscode wsl2_windows_terminal wsl2_git wsl2_oh_my_zsh github_rsa wsl2_nodejs wsl2_dotfiles rbenv_ubuntu rbenv_ruby wsl_browser_variable wls_postgresql checkup alumni_platform wls_slack].freeze
+MAC_OS = %w[intro
+  remote_tools
+  osx_command_line_tools
+  github
+  homebrew
+  osx_sublime_text
+  osx_oh_my_zsh
+  github_rsa
+  dotfiles
+  ssh_osx
+  rbenv_osx
+  rbenv_ruby
+  osx_postgresql
+  osx_security
+  checkup
+  alumni_platform
+  osx_slack
+  osx_preferences].freeze
+
+UBUNTU = %w[intro
+  remote_tools
+  github
+  ubuntu_git
+  ubuntu_sublime_text
+  ubuntu_oh_my_zsh
+  github_rsa
+  dotfiles
+  rbenv_ubuntu
+  rbenv_ruby
+  ubuntu_postgresql
+  ubuntu_inotify
+  ubuntu_extra
+  checkup
+  alumni_platform
+  ubuntu_slack].freeze
+
+WINDOWS = %w[intro
+  wsl2_prereq_intro
+  wsl2_prereq_win10
+  wsl2_prereq_win_version
+  wsl2_prereq_virtualization
+  github
+  remote_tools
+  wsl2_install_wsl
+  wsl2_vscode
+  wsl2_windows_terminal
+  wsl2_git
+  wsl2_oh_my_zsh
+  github_rsa
+  wsl2_nodejs
+  wsl2_dotfiles
+  rbenv_ubuntu
+  rbenv_ruby
+  wsl_browser_variable
+  wls_postgresql
+  checkup
+  alumni_platform
+  wls_slack].freeze
+
 filenames = {
   'macOS.md' => MAC_OS,
   'UBUNTU.md' => UBUNTU,


### PR DESCRIPTION
The xcode-select --install command systematically fails with error message:

```
Xcode is not currently available from the Software Update server
```

Updating the Software Update catalog may help according to https://stackoverflow.com/questions/19907576/xcode-is-not-currently-available-from-the-software-update-server/44234214#44234214