### PR TITLE
Add nvm to setup

### DIFF
--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -363,6 +363,34 @@ Rerun the command to install the gems.
 (or the Terminal) telling you to do so.
 
 
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.
+
+
 ## Postgresql
 
 In a few weeks, we'll talk about SQL and Databases and you'll need something called Postgresql,

--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -85,7 +85,7 @@ Sublime Text is free without any time limitation but a popup will appear every t
 We will use the shell named `zsh` instead of `bash`, the default one.
 
 ```bash
-sudo apt install -y zsh curl vim nodejs imagemagick jq
+sudo apt install -y zsh curl vim imagemagick jq
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 # it will ask for your session password
 ```

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -678,7 +678,7 @@ We will use the shell named `zsh` instead of `bash`, the default one.
 
 ```bash
 # it will ask for your session password
-sudo apt install -y zsh curl vim nodejs imagemagick jq
+sudo apt install -y zsh curl vim imagemagick jq
 ```
 ```bash
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
@@ -703,8 +703,8 @@ At then end, your terminal should look like this:
   <summary>Error: "chsh command unsuccessful. Change your default shell manually."</summary>
 
   &nbsp;
-  
-  
+
+
   You probably typed the wrong password when asked.
   Starting the script again will not work as it will try to create a configuration folder that now already exists !
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1012,6 +1012,34 @@ Rerun the command to install the gems.
 (or the Terminal) telling you to do so.
 
 
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.
+
+
 ## Linking your default browser to Ubuntu
 To be sure that you can interact with your browser installed on Windows from your new Ubuntu terminal, we need to set it as your default browser there.
 

--- a/_partials/osx_nvm.md
+++ b/_partials/osx_nvm.md
@@ -1,0 +1,26 @@
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+brew install nvm
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.

--- a/_partials/ubuntu_nvm.md
+++ b/_partials/ubuntu_nvm.md
@@ -1,0 +1,26 @@
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.

--- a/_partials/ubuntu_oh_my_zsh.md
+++ b/_partials/ubuntu_oh_my_zsh.md
@@ -3,7 +3,7 @@
 We will use the shell named `zsh` instead of `bash`, the default one.
 
 ```bash
-sudo apt install -y zsh curl vim nodejs imagemagick jq
+sudo apt install -y zsh curl vim imagemagick jq
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 # it will ask for your session password
 ```

--- a/_partials/wsl2_oh_my_zsh.md
+++ b/_partials/wsl2_oh_my_zsh.md
@@ -4,7 +4,7 @@ We will use the shell named `zsh` instead of `bash`, the default one.
 
 ```bash
 # it will ask for your session password
-sudo apt install -y zsh curl vim nodejs imagemagick jq
+sudo apt install -y zsh curl vim imagemagick jq
 ```
 ```bash
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
@@ -29,8 +29,8 @@ At then end, your terminal should look like this:
   <summary>Error: "chsh command unsuccessful. Change your default shell manually."</summary>
 
   &nbsp;
-  
-  
+
+
   You probably typed the wrong password when asked.
   Starting the script again will not work as it will try to create a configuration folder that now already exists !
 

--- a/build.rb
+++ b/build.rb
@@ -14,6 +14,7 @@ MAC_OS = %w[intro
   ssh_osx
   rbenv_osx
   rbenv_ruby
+  osx_nvm
   osx_postgresql
   osx_security
   checkup

--- a/build.rb
+++ b/build.rb
@@ -32,6 +32,7 @@ UBUNTU = %w[intro
   dotfiles
   rbenv_ubuntu
   rbenv_ruby
+  ubuntu_nvm
   ubuntu_postgresql
   ubuntu_inotify
   ubuntu_extra

--- a/build.rb
+++ b/build.rb
@@ -57,6 +57,7 @@ WINDOWS = %w[intro
   wsl2_dotfiles
   rbenv_ubuntu
   rbenv_ruby
+  ubuntu_nvm
   wsl_browser_variable
   wls_postgresql
   checkup

--- a/macOS.md
+++ b/macOS.md
@@ -464,6 +464,34 @@ Rerun the command to install the gems.
 (or the Terminal) telling you to do so.
 
 
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+brew install nvm
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.
+
+
 ## Postgresql
 
 In a few weeks, we'll talk about SQL and Databases and you'll need something called Postgresql,


### PR DESCRIPTION
Fixes #214

I added the nvm / node setup guidelines for macOS after running a test on my machine with ruby 2.6.6 / rails 6.0.3.4 versions: webpacker seems to work fine with the LTS version of Node ([14.15.0](https://nodejs.org/en/)) 🎉 
Let's add guidelines for Linux and Windows too 🚀 
- @dmilon could you adapt the guidelines to Linux and run a quick test on your machine (after uninstalling your current versions of nvm / node)?
- @barangerbenjamin could you run a quick test on your WSL setup too?
No rush for this, let's do it by the end of the year to start with a fresh setup in 2021 👍 
Thank you 🙏 