### PR TITLE
wip - Add instructions for brew with Apple ARM

### DIFF
--- a/_partials/homebrew.md
+++ b/_partials/homebrew.md
@@ -30,10 +30,6 @@ To get Homebrew working, let’s install it using Rosetta:
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
-```
-alias ibrew='arch -x86_64 /usr/local/bin/brew'
-```
-
 </details>
 
 ---

--- a/_partials/homebrew.md
+++ b/_partials/homebrew.md
@@ -17,7 +17,7 @@ This will ask for your confirmation (hit `Enter`) and your laptop session passwo
 
   &nbsp;
   
-  :warning: Brew is actually not 100% compatible with macOS 11 Big Sur. oOu can [check the status on the issue](https://github.com/Homebrew/brew/issues/7857).
+  :warning: `brew` is actually not 100% compatible with macOS 11 Big Sur. You can [check the status on the issue](https://github.com/Homebrew/brew/issues/7857).
 
 ```bash
 # Apple ARM processor only!
@@ -28,6 +28,10 @@ Rerun the Homebrew installer under Rosetta 2.
 To get Homebrew working, let’s install it using Rosetta:
 ```bash
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
+
+```
+alias ibrew='arch -x86_64 /usr/local/bin/brew'
 ```
 
 </details>

--- a/_partials/homebrew.md
+++ b/_partials/homebrew.md
@@ -10,6 +10,30 @@ To do so, open your Terminal and run:
 
 This will ask for your confirmation (hit `Enter`) and your laptop session password.
 
+---
+
+<details>
+  <summary>Click here if you are using <bold>Apple ARM</bold></summary>
+
+  &nbsp;
+  
+  :warning: Brew is actually not 100% compatible with macOS 11 Big Sur. oOu can [check the status on the issue](https://github.com/Homebrew/brew/issues/7857).
+
+```bash
+# Apple ARM processor only!
+Homebrew is not (yet) supported on ARM processors!
+Rerun the Homebrew installer under Rosetta 2.
+```
+
+To get Homebrew working, let’s install it using Rosetta:
+```bash
+arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
+
+</details>
+
+---
+
 If you already have Homebrew, it will tell you so, that's fine, go on.
 
 Then install some useful software:


### PR DESCRIPTION
Classic Homebrew is not working with the new Apple M1 chip.
To get Homebrew working, let’s install it using Rosetta

---

Later in the setup

```
brew install rbenv
```

```
Error: Cannot install in Homebrew on ARM processor in Intel default prefix (/usr/local)!
```

Solved with the alias `ibrew`
```
 alias ibrew='arch -x86_64 /usr/local/bin/brew'
```

```
ibrew install rbenv ruby-build
```

---

### ruby version

The build is failing 

```
rbenv install 2.6.6
rbenv install 2.7.2
```

```
BUILD FAILED (macOS 11.0 using ruby-build 20201118)
```

<img width="563" alt="image" src="https://user-images.githubusercontent.com/360936/100225003-e22ba400-2f1d-11eb-92ad-cda09168d036.png">