### PR TITLE
Onboarding warning

### DIFF
--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -428,7 +428,8 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
+:warning: If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already.
+If you are unsure about what to do, you can follow [this link](https://kitt.lewagon.com/). If you are already logged in, you can safely skip this section. If you are not logged in, click on `Enter Kitt as a Student`. If you manage to login, you can safely skip this step. Otherwise ask a teacher whether you should have received an email or follow the instructions below.
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -428,7 +428,7 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -428,6 +428,7 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1129,6 +1129,7 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1129,7 +1129,8 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
+:warning: If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already.
+If you are unsure about what to do, you can follow [this link](https://kitt.lewagon.com/). If you are already logged in, you can safely skip this section. If you are not logged in, click on `Enter Kitt as a Student`. If you manage to login, you can safely skip this step. Otherwise ask a teacher whether you should have received an email or follow the instructions below.
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1129,7 +1129,7 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/_partials/alumni_platform.md
+++ b/_partials/alumni_platform.md
@@ -1,4 +1,5 @@
 ## Alumni
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/_partials/alumni_platform.md
+++ b/_partials/alumni_platform.md
@@ -1,5 +1,5 @@
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/_partials/alumni_platform.md
+++ b/_partials/alumni_platform.md
@@ -1,5 +1,6 @@
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
+:warning: If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already.
+If you are unsure about what to do, you can follow [this link](https://kitt.lewagon.com/). If you are already logged in, you can safely skip this section. If you are not logged in, click on `Enter Kitt as a Student`. If you manage to login, you can safely skip this step. Otherwise ask a teacher whether you should have received an email or follow the instructions below.
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/macOS.md
+++ b/macOS.md
@@ -513,7 +513,7 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/macOS.md
+++ b/macOS.md
@@ -513,6 +513,7 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
+:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step and follow the instructions in the email you received. If you are unsure, please ask a teacher for help.**
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 

--- a/macOS.md
+++ b/macOS.md
@@ -513,7 +513,8 @@ It should tell you if your workstation is ready :) If not, ask a teacher.
 
 
 ## Alumni
-:warning: **If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already. If you are unsure, please ask a teacher for help.**
+:warning: If you have received an email from Le Wagon inviting you to sign up on Kitt (our learning platform), you can safely skip this step. Instead, please follow the instructions in the email you received if you haven't done so already.
+If you are unsure about what to do, you can follow [this link](https://kitt.lewagon.com/). If you are already logged in, you can safely skip this section. If you are not logged in, click on `Enter Kitt as a Student`. If you manage to login, you can safely skip this step. Otherwise ask a teacher whether you should have received an email or follow the instructions below.
 
 Register as a Wagon alumni by going to [kitt.lewagon.com/onboarding](http://kitt.lewagon.com/onboarding). Select your batch, sign in with GitHub and enter all your information.
 


### PR DESCRIPTION
As of January, applicants might receive an invitation email before the start of their batch to get onboarded on kitt if the admission manager decides to do so. Therefore we added a warning message in the setup to make sure they don't onboard themselves twice on Kitt
