### PR TITLE
Add mandatory new option to brew list

### DIFF
--- a/macOS.md
+++ b/macOS.md
@@ -129,7 +129,7 @@ brew update
 Error message or not, proceed running the following in the terminal (you can copy / paste all the lines at once).
 
 ```bash
-function install_or_upgrade { brew ls | grep $1 > /dev/null; if (($? == 0)); then brew upgrade $1; else brew install $1; fi }
+function install_or_upgrade { if brew list --formula | grep -q $1; then brew upgrade $1; else brew install $1; fi }
 install_or_upgrade "git"
 install_or_upgrade "wget"
 install_or_upgrade "imagemagick"


### PR DESCRIPTION
Currently this `install_or_update` does not work as expected given the error message with `brew list`. If always installs the software as a result.

![image](https://user-images.githubusercontent.com/16181471/102942917-f16b2680-44b6-11eb-9ba4-be8d71e08c01.png)

![image](https://user-images.githubusercontent.com/16181471/102943219-bd443580-44b7-11eb-9a37-0d26489cbdbe.png)

Took the liberty to simplify the ternary as well (removed `/dev/null`)

To test:

`function install_or_upgrade { if brew list --formula | grep -q $1; then brew upgrade $1; else brew install $1; fi }`
`brew list --formula | grep git` # should contain git
`install_or_upgrade "git"` # should upgrade git

`brew uninstall git`
`brew list --formula  | grep git` # should not contain git
`install_or_upgrade "git"` # should install git