### PR TITLE
Install nvm before running dotfiles/install.sh

### DIFF
--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -252,6 +252,34 @@ echo "Hello [Le Wagon](https://www.lewagon.com) :wave:" | gh gist create -d "Sta
 This line should open your browser on the newly created gist page. See, we've just created a [**Markdown**](https://guides.github.com/features/mastering-markdown/) file!
 
 
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.
+
+
 ## Dotfiles (Standard configuration)
 
 Hackers love to refine and polish their shell and tools.
@@ -432,34 +460,6 @@ Rerun the command to install the gems.
 
 **Never** install a gem with `sudo gem install`! Even if you stumble upon a Stackoverflow answer
 (or the Terminal) telling you to do so.
-
-
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
-
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
-```
-
-Restart your terminal and run the following:
-
-```bash
-nvm -v
-```
-You should see a version. If not, ask a teacher.
-
-Now let's install node:
-
-```bash
-nvm install 14.15.0
-```
-
-When the command returns, run
-
-```bash
-node -v
-```
-
-You should see `v14.15.0`. If not, ask a teacher.
 
 
 ## PostgreSQL

--- a/build.rb
+++ b/build.rb
@@ -11,11 +11,11 @@ MAC_OS = %w[intro
   osx_oh_my_zsh
   github_rsa
   gh_cli
+  osx_nvm
   dotfiles
   ssh_osx
   rbenv_osx
   rbenv_ruby
-  osx_nvm
   osx_postgresql
   osx_security
   checkup
@@ -31,10 +31,10 @@ UBUNTU = %w[intro
   ubuntu_oh_my_zsh
   github_rsa
   gh_cli
+  ubuntu_nvm
   dotfiles
   rbenv_ubuntu
   rbenv_ruby
-  ubuntu_nvm
   ubuntu_postgresql
   ubuntu_inotify
   ubuntu_extra

--- a/macOS.md
+++ b/macOS.md
@@ -314,6 +314,7 @@ echo "Hello [Le Wagon](https://www.lewagon.com) :wave:" | gh gist create -d "Sta
 
 This line should open your browser on the newly created gist page. See, we've just created a [**Markdown**](https://guides.github.com/features/mastering-markdown/) file!
 
+
 ## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
 
 ```bash
@@ -433,7 +434,7 @@ sw_vers
   <summary>Click here if your OS version (ProductVersion line) is less than 10.12</summary>
 
   In order not to re-type your SSH passphrase at every `git push`, you can add these lines to the `~/.ssh/config` file:
-
+  
   First open the `~/.ssh/config` file.
 
   ```bash

--- a/macOS.md
+++ b/macOS.md
@@ -314,6 +314,33 @@ echo "Hello [Le Wagon](https://www.lewagon.com) :wave:" | gh gist create -d "Sta
 
 This line should open your browser on the newly created gist page. See, we've just created a [**Markdown**](https://guides.github.com/features/mastering-markdown/) file!
 
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+brew install nvm
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.
+
 
 ## Dotfiles (Standard configuration)
 
@@ -406,7 +433,7 @@ sw_vers
   <summary>Click here if your OS version (ProductVersion line) is less than 10.12</summary>
 
   In order not to re-type your SSH passphrase at every `git push`, you can add these lines to the `~/.ssh/config` file:
-  
+
   First open the `~/.ssh/config` file.
 
   ```bash
@@ -522,34 +549,6 @@ Rerun the command to install the gems.
 
 **Never** install a gem with `sudo gem install`! Even if you stumble upon a Stackoverflow answer
 (or the Terminal) telling you to do so.
-
-
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
-
-```bash
-brew install nvm
-```
-
-Restart your terminal and run the following:
-
-```bash
-nvm -v
-```
-You should see a version. If not, ask a teacher.
-
-Now let's install node:
-
-```bash
-nvm install 14.15.0
-```
-
-When the command returns, run
-
-```bash
-node -v
-```
-
-You should see `v14.15.0`. If not, ask a teacher.
 
 
 ## PostgreSQL


### PR DESCRIPTION
Moving the nvm install part before the dotfiles part to avoid errors messages in terminal, linked to [these lines](https://github.com/lewagon/dotfiles/blob/master/zshrc#L26-L28) inside `zshrc`.