### PR TITLE
Update setup

### DIFF
--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -252,34 +252,6 @@ echo "Hello [Le Wagon](https://www.lewagon.com) :wave:" | gh gist create -d "Sta
 This line should open your browser on the newly created gist page. See, we've just created a [**Markdown**](https://guides.github.com/features/mastering-markdown/) file!
 
 
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
-
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
-```
-
-Restart your terminal and run the following:
-
-```bash
-nvm -v
-```
-You should see a version. If not, ask a teacher.
-
-Now let's install node:
-
-```bash
-nvm install 14.15.0
-```
-
-When the command returns, run
-
-```bash
-node -v
-```
-
-You should see `v14.15.0`. If not, ask a teacher.
-
-
 ## Dotfiles (Standard configuration)
 
 Hackers love to refine and polish their shell and tools.
@@ -460,6 +432,34 @@ Rerun the command to install the gems.
 
 **Never** install a gem with `sudo gem install`! Even if you stumble upon a Stackoverflow answer
 (or the Terminal) telling you to do so.
+
+
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.
 
 
 ## PostgreSQL

--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -64,7 +64,7 @@ sudo apt install -y git
 Let's now install GitHub [official CLI](https://cli.github.com) (Command Line Interface) with the following commands:
 
 ```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 sudo apt update
 sudo apt install -y gh

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -466,7 +466,7 @@ We use Visual Code Studio for writing code on Windows, because it integrates nic
 For this integration to work, you need to uninstall other code editor, like for example SublimeText, as their WSL integration interferes with the integration of VS Code.
 
 ### Installation
->\- Go the [Visual Studio Code page](https://code.visualstudio.com/download)
+>\- Go to the [Visual Studio Code page](https://code.visualstudio.com/download)
 >\- Choose the Windows version of VS Code
 
 
@@ -512,12 +512,19 @@ For each of these extensions:
 >\- In the browser, accept to use VS Code to install the extension
 >\- In VS Code, click on `install`
 
+For everyone
+- [Sublime Text Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.sublime-keybindings)
 
+For the Web Development bootcamp:
 - [Rails Snippets](https://marketplace.visualstudio.com/items?itemName=hridoy.rails-snippets)
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [ERB Helper Tags](https://marketplace.visualstudio.com/items?itemName=rayhanw.erb-helpers)
 - [ruby-rubocop](https://marketplace.visualstudio.com/items?itemName=misogi.ruby-rubocop)
+
+For the Data Science bootcamp:
 - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+- [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter)
+- [Python Indent](https://marketplace.visualstudio.com/items?itemName=KevinRose.vsc-python-indent)
 
 ### VS Code Settings
 >\- Press `Ctrl` + `,` on your keyboard to open the settings
@@ -564,7 +571,6 @@ code
 &nbsp;&nbsp;&nbsp; :x: If Visual Studio Code does not open, please **contact a teacher**
 
 &nbsp;&nbsp;&nbsp; :white_check_mark: If Visual Studio Code opens, your code editor is ready! :muscle:
-
 
 
 
@@ -725,7 +731,7 @@ sudo apt install -y git apt-transport-https unzip gnome-terminal
 Let's now install GitHub [official CLI](https://cli.github.com) (Command Line Interface) with the following commands:
 
 ```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 sudo apt update
 sudo apt install -y gh

--- a/_partials/ubuntu_git.md
+++ b/_partials/ubuntu_git.md
@@ -14,7 +14,7 @@ sudo apt install -y git
 Let's now install GitHub [official CLI](https://cli.github.com) (Command Line Interface) with the following commands:
 
 ```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 sudo apt update
 sudo apt install -y gh

--- a/_partials/wsl2_git.md
+++ b/_partials/wsl2_git.md
@@ -17,7 +17,7 @@ sudo apt install -y git apt-transport-https unzip gnome-terminal
 Let's now install GitHub [official CLI](https://cli.github.com) (Command Line Interface) with the following commands:
 
 ```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 sudo apt update
 sudo apt install -y gh

--- a/build.rb
+++ b/build.rb
@@ -11,11 +11,11 @@ MAC_OS = %w[intro
   osx_oh_my_zsh
   github_rsa
   gh_cli
-  osx_nvm
   dotfiles
   ssh_osx
   rbenv_osx
   rbenv_ruby
+  osx_nvm
   osx_postgresql
   osx_security
   checkup
@@ -31,10 +31,10 @@ UBUNTU = %w[intro
   ubuntu_oh_my_zsh
   github_rsa
   gh_cli
-  ubuntu_nvm
   dotfiles
   rbenv_ubuntu
   rbenv_ruby
+  ubuntu_nvm
   ubuntu_postgresql
   ubuntu_inotify
   ubuntu_extra

--- a/macOS.md
+++ b/macOS.md
@@ -315,34 +315,6 @@ echo "Hello [Le Wagon](https://www.lewagon.com) :wave:" | gh gist create -d "Sta
 This line should open your browser on the newly created gist page. See, we've just created a [**Markdown**](https://guides.github.com/features/mastering-markdown/) file!
 
 
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
-
-```bash
-brew install nvm
-```
-
-Restart your terminal and run the following:
-
-```bash
-nvm -v
-```
-You should see a version. If not, ask a teacher.
-
-Now let's install node:
-
-```bash
-nvm install 14.15.0
-```
-
-When the command returns, run
-
-```bash
-node -v
-```
-
-You should see `v14.15.0`. If not, ask a teacher.
-
-
 ## Dotfiles (Standard configuration)
 
 Hackers love to refine and polish their shell and tools.
@@ -550,6 +522,34 @@ Rerun the command to install the gems.
 
 **Never** install a gem with `sudo gem install`! Even if you stumble upon a Stackoverflow answer
 (or the Terminal) telling you to do so.
+
+
+## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+
+```bash
+brew install nvm
+```
+
+Restart your terminal and run the following:
+
+```bash
+nvm -v
+```
+You should see a version. If not, ask a teacher.
+
+Now let's install node:
+
+```bash
+nvm install 14.15.0
+```
+
+When the command returns, run
+
+```bash
+node -v
+```
+
+You should see `v14.15.0`. If not, ask a teacher.
 
 
 ## PostgreSQL


### PR DESCRIPTION
- [x] Adding explicitly the protocol and port to the `apt-key` command

Some Windows computers couldn't `sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0`. 

I found a fix [here](https://unix.stackexchange.com/a/110594). Adding this to the setup will avoid future problems. 

- [x] move `nvm` part after the dotfiles part so that `nvm` is executable and the node installation is working. 

Running `nvm install 14.15.0` requires `nvm` to be in the `PATH` which is usually not the case before the `dotfiles` part. Let's move the `nvm` part after the `dotfiles`. 