### PR TITLE
ensure that existing zoom versions are at least 5.4

### DIFF
--- a/_partials/remote_tools.md
+++ b/_partials/remote_tools.md
@@ -4,6 +4,8 @@ To be able to interact when we are not in the same physical room, we will be usi
 
 ### Zoom
 
+⚠️ If you already have Zoom installed, please make sure that the version is at least **5.4**. Otherwise, you will not be able to use breakout rooms in order to work with your buddy.
+
 Zoom is a video conferencing tool. To create an account and install the app, go to [https://zoom.us/download](https://zoom.us/download) and under **Zoom Client for Meetings** click the **Download** button. Open the file you have just downloaded. A progress bar will appear, then Zoom will start. Click on **Connection** and create an account with the **Sign Up Free** option:
 
 ![zoom-sign-up-free.png](images/zoom-sign-up-free.png)


### PR DESCRIPTION

During the data part time setup, a few students had Zoom already installed on their machine with a version < 5.4.
They consequently ignored the zoom installation paragraph.
During the following remote session, they where unable to join the **breakout rooms**.
