### PR TITLE
update instructions to check $BROWSER

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -907,15 +907,15 @@ To be sure that you can interact with your browser installed on Windows from you
 </details>
 
 
-Please make sure that the following command returns "Browser defined 👌":
+👉 Restart your terminal
+
+Then please make sure that the following command returns "Browser defined 👌":
 
 ```bash
 [ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
 ```
 
 If it does not, choose a browser in the list above and execute the corresponding command.
-
-Restart your terminal.
 
 
 ## GitHub CLI

--- a/_partials/wsl_browser_variable.md
+++ b/_partials/wsl_browser_variable.md
@@ -71,12 +71,12 @@ To be sure that you can interact with your browser installed on Windows from you
 </details>
 
 
-Please make sure that the following command returns "Browser defined 👌":
+👉 Restart your terminal
+
+Then please make sure that the following command returns "Browser defined 👌":
 
 ```bash
 [ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
 ```
 
 If it does not, choose a browser in the list above and execute the corresponding command.
-
-Restart your terminal.


### PR DESCRIPTION
make sure that the students restart their terminal in order for the $BROWSER env var to be set by `~/.zshrc` before the verification

follows https://github.com/lewagon/setup/issues/259
