### PR TITLE
add yarn to setup

### DIFF
--- a/UBUNTU.md
+++ b/UBUNTU.md
@@ -436,7 +436,7 @@ Rerun the command to install the gems.
 (or the Terminal) telling you to do so.
 
 
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+## Node (with [nvm](https://github.com/nvm-sh/nvm))
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
@@ -462,6 +462,20 @@ node -v
 ```
 
 You should see `v14.15.0`. If not, ask a teacher.
+
+
+## yarn (https://classic.yarnpkg.com/en/docs/install)
+
+```bash
+npm install --global yarn
+```
+
+Restart your terminal and run the following:
+
+```bash
+yarn -v
+```
+You should see a version. If not, ask a teacher.
 
 
 ## PostgreSQL

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1157,7 +1157,7 @@ Rerun the command to install the gems.
 (or the Terminal) telling you to do so.
 
 
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+## Node (with [nvm](https://github.com/nvm-sh/nvm))
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
@@ -1183,6 +1183,20 @@ node -v
 ```
 
 You should see `v14.15.0`. If not, ask a teacher.
+
+
+## yarn (https://classic.yarnpkg.com/en/docs/install)
+
+```bash
+npm install --global yarn
+```
+
+Restart your terminal and run the following:
+
+```bash
+yarn -v
+```
+You should see a version. If not, ask a teacher.
 
 
 ## PostgreSQL

--- a/_partials/nvm.md
+++ b/_partials/nvm.md
@@ -1,4 +1,4 @@
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+## Node (with [nvm](https://github.com/nvm-sh/nvm))
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh

--- a/_partials/osx_nvm.md
+++ b/_partials/osx_nvm.md
@@ -1,4 +1,4 @@
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+## Node (with [nvm](https://github.com/nvm-sh/nvm))
 
 ```bash
 brew install nvm

--- a/_partials/yarn.md
+++ b/_partials/yarn.md
@@ -1,0 +1,12 @@
+## yarn (https://classic.yarnpkg.com/en/docs/install)
+
+```bash
+npm install --global yarn
+```
+
+Restart your terminal and run the following:
+
+```bash
+yarn -v
+```
+You should see a version. If not, ask a teacher.

--- a/build.rb
+++ b/build.rb
@@ -17,6 +17,7 @@ MAC_OS = %w[intro
   rbenv_osx
   rbenv_ruby
   nvm
+  yarn
   osx_postgresql
   osx_security
   checkup
@@ -36,6 +37,7 @@ UBUNTU = %w[intro
   rbenv_ubuntu
   rbenv_ruby
   nvm
+  yarn
   ubuntu_postgresql
   ubuntu_inotify
   ubuntu_extra
@@ -62,6 +64,7 @@ WINDOWS = %w[intro
   rbenv_ubuntu
   rbenv_ruby
   nvm
+  yarn
   wls_postgresql
   checkup
   wsl_explorer

--- a/macOS.md
+++ b/macOS.md
@@ -605,7 +605,7 @@ Rerun the command to install the gems.
 (or the Terminal) telling you to do so.
 
 
-## Installing Node (with [nvm](https://github.com/nvm-sh/nvm))
+## Node (with [nvm](https://github.com/nvm-sh/nvm))
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | zsh
@@ -631,6 +631,20 @@ node -v
 ```
 
 You should see `v14.15.0`. If not, ask a teacher.
+
+
+## yarn (https://classic.yarnpkg.com/en/docs/install)
+
+```bash
+npm install --global yarn
+```
+
+Restart your terminal and run the following:
+
+```bash
+yarn -v
+```
+You should see a version. If not, ask a teacher.
 
 
 ## PostgreSQL

--- a/utils/install_node.sh
+++ b/utils/install_node.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-cd ~
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash
-source ~/.zshrc
-nvm install 14.0.0


### PR DESCRIPTION
Following https://github.com/lewagon/fullstack-challenges/issues/1522

I propose that we move all our scattered `yarn` installation instructions to a single place in the setup to keep one single source of truth and point the lectures to the setup instead, just as we did for `node`. 

Moreover, installing `yarn` via `npm` is now the [recommended](https://classic.yarnpkg.com/en/docs/install#mac-stable) way, is cross-platform and pretty easy since `npm` is installed with `node`. 

TODO after merge, check anchors: 
- [ ] https://github.com/lewagon/setup/blob/master/WINDOWS.md#node-with-nvm
- [ ] https://github.com/lewagon/setup/blob/master/WINDOWS.md#yarn