### PR TITLE
fix lists rendered in markdown

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -468,16 +468,16 @@ We use Visual Code Studio for writing code on Windows, because it integrates nic
 For this integration to work, you need to uninstall other code editor, like for example SublimeText, as their WSL integration interferes with the integration of VS Code.
 
 ### Installation
->\- Go to the [Visual Studio Code page](https://code.visualstudio.com/download)
->\- Choose the Windows version of VS Code
+- Go to the [Visual Studio Code page](https://code.visualstudio.com/download)
+- Choose the Windows version of VS Code
 
 
 The tool should start to download automatically.
 
->\- Open the file you have just downloaded.
->\- Install it with a few options:
->    \- Register VS Code as an editor for supported file types
->    \- Let the other options as they are
+- Open the file you have just downloaded.
+- Install it with a few options:
+    - Register VS Code as an editor for supported file types
+    - Let the other options as they are
 
 ![VS Code install](images/vscode-install.png)
 
@@ -495,11 +495,11 @@ The tool should start to download automatically.
 In VS Code:
 
 
->\- Click on `File`
->\- Click on `Preferences`
->\- Click on `Keymaps`
->\- Click on `Sublime Text Keymap and Settings Importer`
->\- Click on `Install`
+- Click on `File`
+- Click on `Preferences`
+- Click on `Keymaps`
+- Click on `Sublime Text Keymap and Settings Importer`
+- Click on `Install`
 
 
 ### VS Code Extensions
@@ -510,9 +510,9 @@ Let's gain time now and add other extensions that will be helpful during your Bo
 For each of these extensions:
 
 
->\- On the web page, click on `install`
->\- In the browser, accept to use VS Code to install the extension
->\- In VS Code, click on `install`
+- On the web page, click on `install`
+- In the browser, accept to use VS Code to install the extension
+- In VS Code, click on `install`
 
 For everyone
 - [Sublime Text Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.sublime-keybindings)
@@ -529,9 +529,9 @@ For the Data Science bootcamp:
 - [Python Indent](https://marketplace.visualstudio.com/items?itemName=KevinRose.vsc-python-indent)
 
 ### VS Code Settings
->\- Press `Ctrl` + `,` on your keyboard to open the settings
->\- In the search bar, type `emmet`
->\- Click on the first **`Edit in settings.json`** link
+- Press `Ctrl` + `,` on your keyboard to open the settings
+- In the search bar, type `emmet`
+- Click on the first **`Edit in settings.json`** link
 
 
 Paste the following just before the last `}`:

--- a/_partials/wsl2_vscode.md
+++ b/_partials/wsl2_vscode.md
@@ -5,16 +5,16 @@ We use Visual Code Studio for writing code on Windows, because it integrates nic
 For this integration to work, you need to uninstall other code editor, like for example SublimeText, as their WSL integration interferes with the integration of VS Code.
 
 ### Installation
->\- Go to the [Visual Studio Code page](https://code.visualstudio.com/download)
->\- Choose the Windows version of VS Code
+- Go to the [Visual Studio Code page](https://code.visualstudio.com/download)
+- Choose the Windows version of VS Code
 
 
 The tool should start to download automatically.
 
->\- Open the file you have just downloaded.
->\- Install it with a few options:
->    \- Register VS Code as an editor for supported file types
->    \- Let the other options as they are
+- Open the file you have just downloaded.
+- Install it with a few options:
+    - Register VS Code as an editor for supported file types
+    - Let the other options as they are
 
 ![VS Code install](images/vscode-install.png)
 
@@ -32,11 +32,11 @@ The tool should start to download automatically.
 In VS Code:
 
 
->\- Click on `File`
->\- Click on `Preferences`
->\- Click on `Keymaps`
->\- Click on `Sublime Text Keymap and Settings Importer`
->\- Click on `Install`
+- Click on `File`
+- Click on `Preferences`
+- Click on `Keymaps`
+- Click on `Sublime Text Keymap and Settings Importer`
+- Click on `Install`
 
 
 ### VS Code Extensions
@@ -47,9 +47,9 @@ Let's gain time now and add other extensions that will be helpful during your Bo
 For each of these extensions:
 
 
->\- On the web page, click on `install`
->\- In the browser, accept to use VS Code to install the extension
->\- In VS Code, click on `install`
+- On the web page, click on `install`
+- In the browser, accept to use VS Code to install the extension
+- In VS Code, click on `install`
 
 For everyone
 - [Sublime Text Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.sublime-keybindings)
@@ -66,9 +66,9 @@ For the Data Science bootcamp:
 - [Python Indent](https://marketplace.visualstudio.com/items?itemName=KevinRose.vsc-python-indent)
 
 ### VS Code Settings
->\- Press `Ctrl` + `,` on your keyboard to open the settings
->\- In the search bar, type `emmet`
->\- Click on the first **`Edit in settings.json`** link
+- Press `Ctrl` + `,` on your keyboard to open the settings
+- In the search bar, type `emmet`
+- Click on the first **`Edit in settings.json`** link
 
 
 Paste the following just before the last `}`:


### PR DESCRIPTION
Windows instructions for VSCode were not rendering correctly:

![image](https://user-images.githubusercontent.com/39556343/112177250-09a72a80-8bf9-11eb-9dce-8bf8883784ce.png)

This PR is fixing this issue and displaying the list rendered properly in markdown:
![image](https://user-images.githubusercontent.com/39556343/112177341-1b88cd80-8bf9-11eb-970b-593819e5dc64.png)

