### PR TITLE
Also accept VS Code as git editor in check script

### DIFF
--- a/check.rb
+++ b/check.rb
@@ -73,6 +73,8 @@ def check_all
     editor = `git config --global core.editor`
     if editor.match(/subl/i)
       [ true, "Sublime Text is your default git editor"]
+    elsif editor.chomp == 'code --wait'
+      [ true, "Visual Studio Code is your default git editor"]
     else
       [ false, "Ask a teacher to check your ~/.gitconfig editor setup. Right now, it's `#{editor.chomp}`"]
     end


### PR DESCRIPTION
Since [we switched to VS Code on the windows setup](https://github.com/lewagon/setup/blob/master/WINDOWS.md#visual-studio-code) might as well not complain about it being the git editor.