### PR TITLE
Fix `gh` setup wording

### DIFF
--- a/_partials/gh_cli.md
+++ b/_partials/gh_cli.md
@@ -19,7 +19,7 @@ You will get the following output:
 - Press Enter to open github.com in your browser...
 ```
 
-Select and copy the code (`0EF9-D015` in the example), then type `Enter`. Your browser will open and ask you to authorize GitHub CLI to use your GitHub account. Accept and wait a bit. Come back to the terminal, type `Enter` again, and that should be it :tada:
+Select and copy the code (`0EF9-D015` in the example), then press `Enter`. Your browser will open and ask you to authorize GitHub CLI to use your GitHub account. Accept and wait a bit. Come back to the terminal, press `Enter` again, and that should be it :tada:
 
 To check that you are properly connected, type:
 


### PR DESCRIPTION
 - change `type enter`  to `press enter` in `gh` setup section because they should press instead of type
 
 Noticed this while translating the guide into Chinese.