### PR TITLE
Wrong path on check.rb download

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -1017,7 +1017,7 @@ Let's check if you successfully installed everything.
 Quit all opened Terminal, open a new one and run the following commands:
 
 ```bash
-curl -Ls https://raw.githubusercontent.com/lewagon/master/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
+curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 
 :check_mark: If you get a green `Awesome! Your computer is now ready!`, then you're good :+1:


### PR DESCRIPTION
It was pointing to `https://raw.githubusercontent.com/lewagon/master/master/check.rb` instead of `https://raw.githubusercontent.com/lewagon/setup/master/check.rb`, resulting in the script trying to run `404: Not Found` as if it were a ruby file. 

