### PR TITLE
Pass Rosetta edits & Add "disable ssh passphrase" details

### DIFF
--- a/_partials/macos_apple_silicon.md
+++ b/_partials/macos_apple_silicon.md
@@ -43,6 +43,4 @@ Press `CMD` + `I` on the Terminal Rosetta app, then check the box "Open using Ro
 
 ⚠️ From now on during the bootcamp, whenever you are asked to open a Terminal, you will use the **Terminal Rosetta** app.
 
-Launch the Terminal app. You will be prompted to install Rosetta. Click Install.
-
 </details>

--- a/_partials/windows_ssh.md
+++ b/_partials/windows_ssh.md
@@ -2,13 +2,22 @@
 
 You don't want to be asked for your passphrase every time you communicate with a distant repository. So, you need to add the plugin `ssh-agent` to `oh my zsh`:
 
+First, open the `.zshrc` file:
+```bash
+export GITHUB_USERNAME=`gh api user | jq -r '.login'`
+echo $GITHUB_USERNAME
+cd ~/code/$GITHUB_USERNAME/dotfiles
+code .zshrc
+```
+
+Then:
 - Spot the line starting with `plugins=`
 - Add `ssh-agent` at the end of the plugins list
 
 The list should look like:
 
 ```bash
-plugins=(gitfast last-working-dir common-aliases zsh-syntax-highlighting history-substring-search ssh-agent)
+plugins=(gitfast last-working-dir common-aliases zsh-syntax-highlighting history-substring-search pyenv ssh-agent)
 ```
 
 :heavy_check_mark: Save the `.zshrc` file with `CTRL` + `S` and close your text editor.

--- a/macos.md
+++ b/macos.md
@@ -87,8 +87,6 @@ Press `CMD` + `I` on the Terminal Rosetta app, then check the box "Open using Ro
 
 ⚠️ From now on during the bootcamp, whenever you are asked to open a Terminal, you will use the **Terminal Rosetta** app.
 
-Launch the Terminal app. You will be prompted to install Rosetta. Click Install.
-
 </details>
 
 

--- a/windows.md
+++ b/windows.md
@@ -802,6 +802,7 @@ cd ~/code/$GITHUB_USERNAME/dotfiles
 code .zshrc
 ```
 
+Then:
 - Spot the line starting with `plugins=`
 - Add `ssh-agent` at the end of the plugins list
 

--- a/windows.md
+++ b/windows.md
@@ -794,13 +794,21 @@ Please now **quit** all your opened terminal windows.
 
 You don't want to be asked for your passphrase every time you communicate with a distant repository. So, you need to add the plugin `ssh-agent` to `oh my zsh`:
 
+First, open the `.zshrc` file:
+```bash
+export GITHUB_USERNAME=`gh api user | jq -r '.login'`
+echo $GITHUB_USERNAME
+cd ~/code/$GITHUB_USERNAME/dotfiles
+code .zshrc
+```
+
 - Spot the line starting with `plugins=`
 - Add `ssh-agent` at the end of the plugins list
 
 The list should look like:
 
 ```bash
-plugins=(gitfast last-working-dir common-aliases zsh-syntax-highlighting history-substring-search ssh-agent)
+plugins=(gitfast last-working-dir common-aliases zsh-syntax-highlighting history-substring-search pyenv ssh-agent)
 ```
 
 :heavy_check_mark: Save the `.zshrc` file with `CTRL` + `S` and close your text editor.


### PR DESCRIPTION
Hi @dmilon,

Following up with today's setup day, I've done the following:
- Added some details about how to open the `zshrc` file. There's also the `pyenv` plugin on that line, I just added it so they could see exactly the same thing on their screen. Most students were lost there. Hope I got it right 🙏 
- Removed the line regarding Rosetta's installation. It's apparently already installed, not prompting the install window anywore.

Let me know what you think.

Thanks 🙏 

---

By the way, who should I contact for the Chinese translation if we merge this?