### PR TITLE
Fix .zshrc typo

### DIFF
--- a/_partials/windows_ssh.md
+++ b/_partials/windows_ssh.md
@@ -3,11 +3,9 @@
 You don't want to be asked for your passphrase every time you communicate with a distant repository. So, you need to add the plugin `ssh-agent` to `oh my zsh`:
 
 First, open the `.zshrc` file:
+
 ```bash
-export GITHUB_USERNAME=`gh api user | jq -r '.login'`
-echo $GITHUB_USERNAME
-cd ~/code/$GITHUB_USERNAME/dotfiles
-code zshrc
+code ~/.zshrc
 ```
 
 Then:

--- a/windows.md
+++ b/windows.md
@@ -795,11 +795,9 @@ Please now **quit** all your opened terminal windows.
 You don't want to be asked for your passphrase every time you communicate with a distant repository. So, you need to add the plugin `ssh-agent` to `oh my zsh`:
 
 First, open the `.zshrc` file:
+
 ```bash
-export GITHUB_USERNAME=`gh api user | jq -r '.login'`
-echo $GITHUB_USERNAME
-cd ~/code/$GITHUB_USERNAME/dotfiles
-code zshrc
+code ~/.zshrc
 ```
 
 Then:


### PR DESCRIPTION
Following [this Slack post](https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1625930339451300) and this related PR https://github.com/lewagon/setup/pull/311. 

There was a typo since the dot was missing: the file to open is `.zshrc` and not `zshrc`. 

Indeed, `~/.zshrc` is a symlink pointing to `~/code/$GITHUB_NICKNAME/dotfiles/zshrc`. 

Since at this point of the setup, the symlink has been implemented, the single command `code ~/.zshrc` is equivalent with the commands: 

```bash
export GITHUB_USERNAME=`gh api user | jq -r '.login'`
echo $GITHUB_USERNAME
cd ~/code/$GITHUB_USERNAME/dotfiles
code .zshrc # with the dot here
```

Let's keep the first unique one for simplicity. 