### PR TITLE
Add Git 2.28 option to rename Master branches to Main as default

### DIFF
--- a/_partials/git.md
+++ b/_partials/git.md
@@ -11,6 +11,7 @@ To install `git`:
 ```bash
 sudo apt update
 sudo apt install -y git
+git config --global init.defaultBranch main
 ````
 
 These commands will ask for your password: type it in.

--- a/_partials/macos_homebrew.md
+++ b/_partials/macos_homebrew.md
@@ -37,3 +37,9 @@ brew upgrade imagemagick || brew install imagemagick
 brew upgrade jq          || brew install jq
 brew upgrade openssl     || brew install openssl
 ```
+
+Configure the newly installed git software:
+
+```bash
+git config --global init.defaultBranch main
+```

--- a/macos.md
+++ b/macos.md
@@ -176,6 +176,7 @@ Configure the newly installed git software:
 git config --global init.defaultBranch main
 ```
 
+
 ## Visual Studio Code
 
 ### Installation

--- a/macos.md
+++ b/macos.md
@@ -170,6 +170,11 @@ brew upgrade jq          || brew install jq
 brew upgrade openssl     || brew install openssl
 ```
 
+Configure the newly installed git software:
+
+```bash
+git config --global init.defaultBranch main
+```
 
 ## Visual Studio Code
 

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -129,6 +129,7 @@ To install `git`:
 ```bash
 sudo apt update
 sudo apt install -y git
+git config --global init.defaultBranch main
 ````
 
 These commands will ask for your password: type it in.

--- a/windows.md
+++ b/windows.md
@@ -480,6 +480,7 @@ To install `git`:
 ```bash
 sudo apt update
 sudo apt install -y git
+git config --global init.defaultBranch main
 ````
 
 These commands will ask for your password: type it in.


### PR DESCRIPTION
As per this [Slack conversation](https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1629908093143600)
  * Git is not ready to switch the default branch name from `master` to `main` yet
  * This PR configures the new default branch name for students to `main` when repos are created on their machine (`git init` as well as `rails new`)

:warning: May be inconsistent with some lectures from AirBnB and Projects.
