### PR TITLE
Use `gh` cli to add SSH key to GitHub

### DIFF
--- a/_partials/ssh_key.md
+++ b/_partials/ssh_key.md
@@ -25,42 +25,15 @@ Now, you will give your **public** key to GitHub.
 In your terminal copy-paste the following command:
 
 ```bash
-cat ~/.ssh/id_ed25519.pub
+gh auth refresh -s write:public_key
 ```
 
-It will prompt on the screen the content of the `id_ed25519.pub` file.
+It will prompt a one time code (####-####) on the screen. Copy it and press `ENTER`, then paste the code in your browser and follow the instructions to **Authorize github**.
 
-- Copy that text from `ssh` to the end of your email address
-- Go to [github.com/settings/ssh](https://github.com/settings/keys)
-- Click on the green button `New SSH key`
-- Fill in the Title with your computer name (`Macbook Pro` for instance)
-- Paste the **key**
-- Finish by clicking on the **Add SSH key** green button.
-
-To check that this step is completed, in the terminal run this.
+Back in the terminal, press `ENTER` and run this:
 
 ```bash
-ssh -T git@github.com
+gh ssh-key add ~/.ssh/id_ed25519.pub
 ```
 
-:warning: You will be prompted a warning, type `yes` then `ENTER`.
-
-This is the expected result:
-
-```
-# Hi --------! You've successfully authenticated, but GitHub does not provide shell access
-```
-
-:heavy_check_mark: If you got this message, the key was added to GitHub successfully :+1:
-
-:x: If you encountered an error, you will have to try again. Do not hesitate to **contact a teacher**.
-
-<details>
-  <summary>If <code>ssh -T git@github.com</code> does not work</summary>
-
-  Try running this command before trying again:
-
-  ```bash
-  ssh-add ~/.ssh/id_ed25519
-  ```
-</details>
+This should return `✓ Public key added to your account`. If not, do not hesitate to **contact a teacher**.

--- a/_partials/ssh_key.md
+++ b/_partials/ssh_key.md
@@ -28,7 +28,7 @@ In your terminal copy-paste the following command:
 gh auth refresh -s write:public_key
 ```
 
-It will prompt a one time code (####-####) on the screen. Copy it and press `ENTER`, then paste the code in your browser and follow the instructions to **Authorize github**.
+It will prompt a one time code (####-####) on the screen. Copy it and press `ENTER`, then paste the code in your browser and follow the instructions to **Authorize GitHub**.
 
 Back in the terminal, press `ENTER` and run this:
 

--- a/build.rb
+++ b/build.rb
@@ -14,8 +14,8 @@ MACOS = %w[
   vscode_liveshare
   macos_terminal
   oh_my_zsh
-  ssh_key
   gh_cli
+  ssh_key
   dotfiles
   macos_rbenv
   ruby
@@ -44,9 +44,9 @@ WINDOWS = %w[
   git
   zsh
   oh_my_zsh
-  ssh_key
   windows_browser
   gh_cli
+  ssh_key
   dotfiles
   windows_ssh
   rbenv
@@ -71,8 +71,8 @@ UBUNTU = %w[
   git
   zsh
   oh_my_zsh
-  ssh_key
   gh_cli
+  ssh_key
   dotfiles
   rbenv
   ruby


### PR DESCRIPTION
# Content of this PR

This replaces the current manual flow of adding the SSH key to GitHub via the UI. Instead, it uses the [`gh ssh-key add`](https://github.com/cli/cli/pull/2990) cli command.

# Notable changes

## Order of sections

In addition to the updated instructions, the order has been modified so that the **SSH Key** section appears only after the **GitHub CLI** setup.

## Removal of `ssh -T git@github.com`

From my tests, once the SSH key has been added to GitHub, running a `git pull` or any equivalent command from a repository connected to the right GH account runs the equivalent of `ssh-add ~/.ssh/id_ed25519`, _i.e._ even if the identity is not present in the SSH agent (running `ssh-add -D` deletes all of them for example if you would like to test), the `~/.ssh/id_ed25519` identity is added back to the SSH agent after running `git pull`.

It might however be worth testing this behavior, especially on Windows and Ubuntu.

An alternative way to test for the correct setup would be to run `gh ssh-key list`, but since the message after running `gh ssh-key add` is very explicit, I don't think that step is necessary anymore, unlike when the setup was done manually in the browser and needed some verification from the terminal.