### PR TITLE
Quick fix - Rescue error on Github Profile Picture

### DIFF
--- a/check.rb
+++ b/check.rb
@@ -20,6 +20,8 @@ def check(label, &block)
   result, message = yield
   $all_good = $all_good && result
   puts result ? "[OK] #{message}".green : "[KO] #{message}".red
+rescue HTTP::Request::UnsupportedSchemeError
+  puts "Test not available for now..."
 end
 
 def check_all


### PR DESCRIPTION
Having an issue with setup day, students cannot check their Github profile pic and it is breaking the other remaining tests.

We'll see how to solve this properly afterwards.

I still need to test it on my computer before we can merge.