### PR TITLE
move exec zsh as last line of code block

### DIFF
--- a/_partials/checkup.md
+++ b/_partials/checkup.md
@@ -2,10 +2,15 @@
 
 Let's check if you successfully installed everything.
 
-In you terminal, run the following commands:
+In you terminal, run the following command:
 
 ```bash
 exec zsh
+```
+
+Then run:
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/_partials/fr/checkup.md
+++ b/_partials/fr/checkup.md
@@ -2,10 +2,15 @@
 
 On va maintenant vérifier que tu as tout installé correctement.
 
-Dans ton terminal, exécute les commandes suivantes :
+Dans ton terminal, exécute la commande suivante :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/_partials/fr/macos_rbenv.md
+++ b/_partials/fr/macos_rbenv.md
@@ -20,11 +20,11 @@ Dans le terminal, exécute :
 
 ```bash
 brew uninstall --force rbenv ruby-build
+exec zsh
 ```
 
 Puis exécute ensuite :
 
 ```bash
-exec zsh
 brew install rbenv
 ```

--- a/_partials/fr/ruby.md
+++ b/_partials/fr/ruby.md
@@ -21,6 +21,11 @@ Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 ruby -v
 ```
 

--- a/_partials/fr/ruby.md
+++ b/_partials/fr/ruby.md
@@ -17,7 +17,7 @@ d’utiliser la version <RUBY_SETUP_VERSION> par défaut.
 rbenv global <RUBY_SETUP_VERSION>
 ```
 
-Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
+**Réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh

--- a/_partials/macos_rbenv.md
+++ b/_partials/macos_rbenv.md
@@ -20,11 +20,11 @@ In the terminal, run:
 
 ```bash
 brew uninstall --force rbenv ruby-build
+exec zsh
 ```
 
 Then run:
 
 ```bash
-exec zsh
 brew install rbenv
 ```

--- a/_partials/ruby.md
+++ b/_partials/ruby.md
@@ -17,11 +17,13 @@ to use the <RUBY_SETUP_VERSION> version by default.
 rbenv global <RUBY_SETUP_VERSION>
 ```
 
-Then **reset** your terminal and check your Ruby version:
+**Reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
 ```
+
+Then run:
 
 ```bash
 ruby -v

--- a/_partials/ruby.md
+++ b/_partials/ruby.md
@@ -21,6 +21,9 @@ Then **reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
+```
+
+```bash
 ruby -v
 ```
 

--- a/macos.fr.md
+++ b/macos.fr.md
@@ -432,7 +432,7 @@ d’utiliser la version 3.0.3 par défaut.
 rbenv global 3.0.3
 ```
 
-Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
+**Réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh

--- a/macos.fr.md
+++ b/macos.fr.md
@@ -403,12 +403,12 @@ Dans le terminal, exécute :
 
 ```bash
 brew uninstall --force rbenv ruby-build
+exec zsh
 ```
 
 Puis exécute ensuite :
 
 ```bash
-exec zsh
 brew install rbenv
 ```
 
@@ -436,6 +436,11 @@ Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 ruby -v
 ```
 
@@ -584,10 +589,15 @@ Pour quitter PostgreSQL, saisis `\q` puis `ENTRÉE`.
 
 On va maintenant vérifier que tu as tout installé correctement.
 
-Dans ton terminal, exécute les commandes suivantes :
+Dans ton terminal, exécute la commande suivante :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/macos.md
+++ b/macos.md
@@ -433,11 +433,13 @@ to use the 3.0.3 version by default.
 rbenv global 3.0.3
 ```
 
-Then **reset** your terminal and check your Ruby version:
+**Reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
 ```
+
+Then run:
 
 ```bash
 ruby -v

--- a/macos.md
+++ b/macos.md
@@ -404,12 +404,12 @@ In the terminal, run:
 
 ```bash
 brew uninstall --force rbenv ruby-build
+exec zsh
 ```
 
 Then run:
 
 ```bash
-exec zsh
 brew install rbenv
 ```
 
@@ -437,6 +437,9 @@ Then **reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
+```
+
+```bash
 ruby -v
 ```
 
@@ -585,10 +588,15 @@ To quit it, type `\q` then `Enter`.
 
 Let's check if you successfully installed everything.
 
-In you terminal, run the following commands:
+In you terminal, run the following command:
 
 ```bash
 exec zsh
+```
+
+Then run:
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/ubuntu.fr.md
+++ b/ubuntu.fr.md
@@ -424,7 +424,7 @@ d’utiliser la version 3.0.3 par défaut.
 rbenv global 3.0.3
 ```
 
-Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
+**Réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh

--- a/ubuntu.fr.md
+++ b/ubuntu.fr.md
@@ -428,6 +428,11 @@ Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 ruby -v
 ```
 
@@ -562,10 +567,15 @@ sudo -u postgres psql --command "CREATE ROLE `whoami` LOGIN createdb;"
 
 On va maintenant vérifier que tu as tout installé correctement.
 
-Dans ton terminal, exécute les commandes suivantes :
+Dans ton terminal, exécute la commande suivante :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -428,6 +428,9 @@ Then **reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
+```
+
+```bash
 ruby -v
 ```
 
@@ -562,10 +565,15 @@ sudo -u postgres psql --command "CREATE ROLE `whoami` LOGIN createdb;"
 
 Let's check if you successfully installed everything.
 
-In you terminal, run the following commands:
+In you terminal, run the following command:
 
 ```bash
 exec zsh
+```
+
+Then run:
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -424,11 +424,13 @@ to use the 3.0.3 version by default.
 rbenv global 3.0.3
 ```
 
-Then **reset** your terminal and check your Ruby version:
+**Reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
 ```
+
+Then run:
 
 ```bash
 ruby -v

--- a/windows.fr.md
+++ b/windows.fr.md
@@ -853,6 +853,11 @@ Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 ruby -v
 ```
 
@@ -1011,10 +1016,15 @@ Ouvre un nouveau terminal.
 
 On va maintenant vérifier que tu as tout installé correctement.
 
-Dans ton terminal, exécute les commandes suivantes :
+Dans ton terminal, exécute la commande suivante :
 
 ```bash
 exec zsh
+```
+
+Puis exécute :
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/windows.fr.md
+++ b/windows.fr.md
@@ -849,7 +849,7 @@ d’utiliser la version 3.0.3 par défaut.
 rbenv global 3.0.3
 ```
 
-Puis **réinitialise** ton ton terminal et vérifie ta version de Ruby :
+**Réinitialise** ton ton terminal et vérifie ta version de Ruby :
 
 ```bash
 exec zsh

--- a/windows.md
+++ b/windows.md
@@ -852,6 +852,9 @@ Then **reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
+```
+
+```bash
 ruby -v
 ```
 
@@ -1010,10 +1013,15 @@ Open a new terminal.
 
 Let's check if you successfully installed everything.
 
-In you terminal, run the following commands:
+In you terminal, run the following command:
 
 ```bash
 exec zsh
+```
+
+Then run:
+
+```bash
 curl -Ls https://raw.githubusercontent.com/lewagon/setup/master/check.rb > _.rb && ruby _.rb && rm _.rb || rm _.rb
 ```
 

--- a/windows.md
+++ b/windows.md
@@ -848,11 +848,13 @@ to use the 3.0.3 version by default.
 rbenv global 3.0.3
 ```
 
-Then **reset** your terminal and check your Ruby version:
+**Reset** your terminal and check your Ruby version:
 
 ```bash
 exec zsh
 ```
+
+Then run:
 
 ```bash
 ruby -v


### PR DESCRIPTION
Fix https://lewagon-alumni.slack.com/archives/C033YB2VC/p1641557695050400

It appears that when you have two zsh commands, the first one being `exec zsh`, the second one is never executed. 

For example: 

```bash
exec zsh
ruby -v
```

doesn't print the Ruby version, even if you copy-paste the whole code block and execute it once. Since `exec zsh` is resetting the zsh instance, it's "erasing" whatever command comes next. 

So whenever we use `exec zsh`, this commands has to be the last command of the code block, otherwise any other following command will not be executed. 

This PR implement the corresponding fixes :pray: 