### PR TITLE
clarification: **Ubuntu** terminal

### DIFF
--- a/_partials/cli_tools.md
+++ b/_partials/cli_tools.md
@@ -7,7 +7,7 @@ Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_
 We will also use [`git`](https://git-scm.com/), a command line software used for version control.
 
 Let's install them, along with other useful tools:
-- Open a terminal
+- Open an **Ubuntu terminal**
 - Copy and paste the following commands:
 
 ```bash

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -140,7 +140,7 @@ Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_
 We will also use [`git`](https://git-scm.com/), a command line software used for version control.
 
 Let's install them, along with other useful tools:
-- Open a terminal
+- Open an **Ubuntu terminal**
 - Copy and paste the following commands:
 
 ```bash

--- a/windows.md
+++ b/windows.md
@@ -556,7 +556,7 @@ Instead of using the default `bash` [shell](https://en.wikipedia.org/wiki/Shell_
 We will also use [`git`](https://git-scm.com/), a command line software used for version control.
 
 Let's install them, along with other useful tools:
-- Open a terminal
+- Open an **Ubuntu terminal**
 - Copy and paste the following commands:
 
 ```bash


### PR DESCRIPTION
Some students try to execute `sudo apt install ...` in a Powershell. This change clarifies that they should open an Ubuntu terminal.