### PR TITLE
add github light theme

### DIFF
--- a/_partials/vscode_extensions.md
+++ b/_partials/vscode_extensions.md
@@ -9,6 +9,7 @@ Copy-paste the following commands in your terminal:
 ```bash
 code --install-extension ms-vscode.sublime-keybindings
 code --install-extension emmanuelbeziat.vscode-great-icons
+code --install-extension github.github-vscode-theme
 code --install-extension MS-vsliveshare.vsliveshare
 code --install-extension rebornix.ruby
 code --install-extension dbaeumer.vscode-eslint

--- a/macos.md
+++ b/macos.md
@@ -170,6 +170,7 @@ Copy-paste the following commands in your terminal:
 ```bash
 code --install-extension ms-vscode.sublime-keybindings
 code --install-extension emmanuelbeziat.vscode-great-icons
+code --install-extension github.github-vscode-theme
 code --install-extension MS-vsliveshare.vsliveshare
 code --install-extension rebornix.ruby
 code --install-extension dbaeumer.vscode-eslint

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -96,6 +96,7 @@ Copy-paste the following commands in your terminal:
 ```bash
 code --install-extension ms-vscode.sublime-keybindings
 code --install-extension emmanuelbeziat.vscode-great-icons
+code --install-extension github.github-vscode-theme
 code --install-extension MS-vsliveshare.vsliveshare
 code --install-extension rebornix.ruby
 code --install-extension dbaeumer.vscode-eslint

--- a/windows.md
+++ b/windows.md
@@ -512,6 +512,7 @@ Copy-paste the following commands in your terminal:
 ```bash
 code --install-extension ms-vscode.sublime-keybindings
 code --install-extension emmanuelbeziat.vscode-great-icons
+code --install-extension github.github-vscode-theme
 code --install-extension MS-vsliveshare.vsliveshare
 code --install-extension rebornix.ruby
 code --install-extension dbaeumer.vscode-eslint


### PR DESCRIPTION
Add default Github light theme to VScode

- It's the one we recommand our teacher to use when they get filmed ([see notion](https://www.notion.so/lewagon/Lecture-video-recording-guidelines-fb2fd65863fa432399fc1a6e44305b3b#da77d412564147dd92075652471f05ff))

- I hope you're OK with it in web dev too? Currently, the default VScode theme is horrible !

[Linked PR in dotfiles](https://github.com/lewagon/dotfiles/compare/vscode-setup?expand=1)