### PR TITLE
Add Superuser attribute to PostgreSQL user

### DIFF
--- a/ubuntu.cn.md
+++ b/ubuntu.cn.md
@@ -514,6 +514,10 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev build-essential
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 
 ## 最后检查
 

--- a/ubuntu.es.md
+++ b/ubuntu.es.md
@@ -542,6 +542,10 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev build-essential
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 
 ## Chequeo
 

--- a/ubuntu.fr.md
+++ b/ubuntu.fr.md
@@ -545,6 +545,10 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev build-essential
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 
 ## Vérification
 

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -550,6 +550,10 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev build-essential
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 
 ## Check-up
 

--- a/windows.cn.md
+++ b/windows.cn.md
@@ -950,6 +950,10 @@ sudo /etc/init.d/postgresql start
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 你可以把PostgreSQL配置成自动启动，这样每次你打开新的终端时，你就不需要执行`sudo /etc/init.d/postgresql start`：
 
 ```bash

--- a/windows.es.md
+++ b/windows.es.md
@@ -966,6 +966,10 @@ sudo /etc/init.d/postgresql start
 sudo -u postgres psql --command "CREATE ROLE `whoami` LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 Puedes configurar PostgreSQL para que inicie automáticamente para no tener que ejecutar el comando `sudo /etc/init.d/postgresql start` cada vez que abras una nueva terminal:
 
 ```bash

--- a/windows.fr.md
+++ b/windows.fr.md
@@ -966,6 +966,10 @@ sudo /etc/init.d/postgresql start
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 Tu peux configurer le démarrage automatique de PostgreSQL afin de ne pas avoir à exécuter `sudo /etc/init.d/postgresql start` chaque fois que tu ouvres un nouveau terminal :
 
 ```bash

--- a/windows.md
+++ b/windows.md
@@ -972,6 +972,10 @@ sudo /etc/init.d/postgresql start
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb;"
 ```
 
+```bash
+sudo -u postgres psql --command "ALTER USER \"`whoami`\" WITH SUPERUSER;"
+```
+
 You can configure PostgreSQL to autostart, so you don't have to execute `sudo /etc/init.d/postgresql start` each time you open a new terminal:
 
 ```bash


### PR DESCRIPTION
As per the Rails guides [Fixtures in action](https://edgeguides.rubyonrails.org/testing.html#fixtures-in-action)

> If you are getting annoying permission errors on running tests, make sure the database user has privilege to disable these triggers in testing environment.

I have only encountered this now while going through the [Turbo Rails Tutorial](https://www.hotrails.dev/turbo-rails) by our Alexandre Ruban, so it does not affect the Le Wagon curriculum. I explain my error messages that led me here in [this #TIL Slack post](https://lewagon-alumni.slack.com/archives/CU4DAKCJY/p1657099343744769).

We do not seed our database from fixtures during the Bootcamp, but some students might do this in their own projects.

I am wondering wether it would be a good idea to add the Superuser attribute to the postgres user we create during setup? 🤔
(May be I learn of good practices against this?) Let's discuss 😄