### PR TITLE
[SP] Set terminal default size in macOS

### DIFF
--- a/_partials/es/macos_terminal.md
+++ b/_partials/es/macos_terminal.md
@@ -4,4 +4,6 @@ Abre una terminal. Haz clic en `Terminal > Preferences` y coloca el tema llamado
 
 ![Pon el tema Pro en la terminal de macOS](images/macos_terminal_pro.png)
 
+En la pestaña "Ventana", configura también tu **Tamaño de la ventana** a Columnas: 200, Filas: 50
+
 **Cierra y reinicia** tu terminal: ahora debería tener un fondo negro que no te cansa tanto la vista.

--- a/_partials/es/vscode_extensions.md
+++ b/_partials/es/vscode_extensions.md
@@ -9,6 +9,7 @@ Copia y pega los siguientes comandos en tu terminal:
 ```bash
 code --install-extension ms-vscode.sublime-keybindings
 code --install-extension emmanuelbeziat.vscode-great-icons
+code --install-extension github.github-vscode-theme
 code --install-extension MS-vsliveshare.vsliveshare
 code --install-extension rebornix.ruby
 code --install-extension dbaeumer.vscode-eslint


### PR DESCRIPTION
Set terminal default size in macOS for Spanish (from [PR #389](https://github.com/lewagon/setup/pull/389))

