### PR TITLE
resurrect windows browser partial

### DIFF
--- a/_partials/cn/windows_browser.md
+++ b/_partials/cn/windows_browser.md
@@ -1,0 +1,95 @@
+## 把你的默认浏览器链接到Ubuntu
+
+为了保证你可以在Ubuntu终端和浏览器进行交互，你需要设置你的默认浏览器。
+
+⚠️ 你需要执行下面的至少一组命令：
+
+
+<details>
+  <summary>用Google Chrome作为默认浏览器</summary>
+
+  &nbsp;
+
+
+  运行下面的命令:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+  如果你看到了错误信息，比如`ls: cannot access...` 那就运行下面的命令：
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  如果没有错误信息，就运行下面这一行:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+</details>
+
+
+<details>
+  <summary>用Mozilla Firefox作为默认浏览器</summary>
+
+  &nbsp;
+
+
+  运行下面的命令:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  如果你看到了错误信息，比如`ls: cannot access...` 那就运行下面的命令：
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  如果没有错误信息，就运行下面这一行:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>用Microsoft Edge作为默认浏览器</summary>
+
+  &nbsp;
+
+
+  运行下面的命令:
+
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+
+重启你的终端。
+
+然后请保证在终端运行下面这行命令后，会返回"Browser defined 👌"这句话：
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+如果没有返回这句话，那在上面的列表中选一个浏览器，然后运行对应的命令。
+
+如果没有的话，
+
+:heavy_check_mark: 如果你看到那条信息，你就可以继续 :+1:
+
+:x: 如果没有，那在上面的列表中选一个浏览器，然后运行对应的命令。然后别忘记重置你的终端：
+
+```bash
+exec zsh
+```
+
+有问题的话，别犹豫**问老师**。

--- a/_partials/es/windows_browser.md
+++ b/_partials/es/windows_browser.md
@@ -1,0 +1,79 @@
+## Conexión de tu navegador predeterminado con Ubuntu
+
+Para asegurarnos de que puedas interactuar desde la terminal de Ubuntu con el navegador que tienes instalado en Windows, debemos definirlo como tu navegador predeterminado aquí.
+
+:warning: Tienes que ejecutar al menos uno de los siguientes comandos:
+
+<details>
+  <summary>Google Chrome como tu navegador predeterminado</summary>
+
+  Ejecuta este comando:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+  Si obtienes un error como este `ls: cannot access...` corre el siguiente comando:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  Si no es el caso, ejecuta lo siguiente:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Mozilla Firefox como tu navegador predeterminado</summary>
+
+  Ejecuta el siguiente comando:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  Si obtienes un error como este `ls: cannot access...` corre el siguiente comando:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  Si no es el caso, ejecuta lo siguiente:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Microsoft Edge como tu navegador predeterminado</summary>
+
+  Ejecuta el siguiente comando:
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+Reinicia tu terminal.
+
+Luego asegúrate de que el siguiente comando devuelva "Browser defined 👌":
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+Si no lo hace pero
+
+:heavy_check_mark: sí obtienes este mensaje, puedes continuar :+1:
+
+:x: De lo contrario, escoge un navegador de la lista de arriba y ejecuta el comando correspondiente. Luego no olvides reiniciar tu terminal:
+
+```bash
+exec zsh
+```
+
+No dudes en **pedirle ayuda a tu profesor**.

--- a/_partials/fr/windows_browser.md
+++ b/_partials/fr/windows_browser.md
@@ -1,0 +1,79 @@
+## Associer ton navigateur par défaut à Ubuntu
+
+Pour que tu puisses interagir avec le navigateur installé sous Windows depuis ton terminal Ubuntu, on doit le définir comme navigateur par défaut.
+
+:warning: Tu dois exécuter au moins une des commandes ci-dessous :
+
+<details>
+ <summary>Google Chrome est ton navigateur par défaut</summary>
+
+Exécute la commande :
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+Si tu obtiens une erreur du type `ls: cannot access...`, exécute la commande suivante :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  Sinon, exécute :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+ <summary>Mozilla Firefox est ton navigateur par défaut</summary>
+
+  Exécute la commande :
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  Si tu obtiens une erreur du type `ls: cannot access...`, exécute la commande suivante :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  Sinon, exécute :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+ <summary>Microsoft Edge est ton navigateur par défaut</summary>
+
+  Exécute la commande :
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+Redémarre ton terminal.
+
+Puis vérifie que la commande suivante renvoie « Browser defined 👌 » :
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+Si ce n’est pas le cas,
+
+:heavy_check_mark: Si tu vois apparaître ce message, tu peux continuer :+1:
+
+:x: Sinon, choisis un navigateur dans la liste ci-dessus et exécute la commande correspondante. Puis n’oublie pas de réinitialiser ton terminal :
+
+```bash
+exec zsh
+```
+
+N’hésite pas à **demander au prof**.

--- a/_partials/windows_browser.md
+++ b/_partials/windows_browser.md
@@ -1,0 +1,79 @@
+## Linking your default browser to Ubuntu
+
+To be sure that you can interact with your browser installed on Windows from your Ubuntu terminal, we need to set it as your default browser there.
+
+:warning: You need to execute at least one of the following commands below:
+
+<details>
+  <summary>Google Chrome as your default browser</summary>
+
+  Run the command:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+  If you get an error like `ls: cannot access...` Run the following command:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  Else run:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Mozilla Firefox as your default browser</summary>
+
+  Run the command:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  If you get an error like `ls: cannot access...` Run the following command:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  Else run:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Microsoft Edge as your default browser</summary>
+
+  Run the command:
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+Restart your terminal.
+
+Then please make sure that the following command returns "Browser defined 👌":
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+If it does not,
+
+:heavy_check_mark: If you got this message, you can continue :+1:
+
+:x: If not, choose a browser in the list above and execute the corresponding command. Then don't forget to reset your terminal:
+
+```bash
+exec zsh
+```
+
+Do not hesitate to **contact a teacher**.


### PR DESCRIPTION
resurrect the windows browser partial from https://github.com/lewagon/setup/pull/365/files#diff-0d317b8f969e02428bf79177fd15fecc77e1e283b9898156baae2d2484e37936

it appears that Ubuntu 22.04 does not support anymore the detection of the windows browser (@vtmoreau)

we are going to use this partial in the data setup, it may be required for the web setup as well