### PR TITLE
add browser env var

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -47,6 +47,7 @@ WINDOWS = %w[
   vscode_liveshare
   cli_tools
   oh_my_zsh
+  windows_browser
   gh_cli
   dotfiles
   ssh_agent

--- a/windows.cn.md
+++ b/windows.cn.md
@@ -612,6 +612,103 @@ sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.
 :x: 如果安装失败的话，请询问**你的老师**
 
 
+## 把你的默认浏览器链接到Ubuntu
+
+为了保证你可以在Ubuntu终端和浏览器进行交互，你需要设置你的默认浏览器。
+
+⚠️ 你需要执行下面的至少一组命令：
+
+
+<details>
+  <summary>用Google Chrome作为默认浏览器</summary>
+
+  &nbsp;
+
+
+  运行下面的命令:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+  如果你看到了错误信息，比如`ls: cannot access...` 那就运行下面的命令：
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  如果没有错误信息，就运行下面这一行:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+</details>
+
+
+<details>
+  <summary>用Mozilla Firefox作为默认浏览器</summary>
+
+  &nbsp;
+
+
+  运行下面的命令:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  如果你看到了错误信息，比如`ls: cannot access...` 那就运行下面的命令：
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  如果没有错误信息，就运行下面这一行:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>用Microsoft Edge作为默认浏览器</summary>
+
+  &nbsp;
+
+
+  运行下面的命令:
+
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+
+重启你的终端。
+
+然后请保证在终端运行下面这行命令后，会返回"Browser defined 👌"这句话：
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+如果没有返回这句话，那在上面的列表中选一个浏览器，然后运行对应的命令。
+
+如果没有的话，
+
+:heavy_check_mark: 如果你看到那条信息，你就可以继续 :+1:
+
+:x: 如果没有，那在上面的列表中选一个浏览器，然后运行对应的命令。然后别忘记重置你的终端：
+
+```bash
+exec zsh
+```
+
+有问题的话，别犹豫**问老师**。
+
+
 ## GitHub CLI
 
 CLI是[Command-line Interface（命令行界面）](https://baike.baidu.com/item/%E5%91%BD%E4%BB%A4%E8%A1%8C%E7%95%8C%E9%9D%A2/9910197?fr=aladdin)的首字母缩写。

--- a/windows.es.md
+++ b/windows.es.md
@@ -616,6 +616,87 @@ Cuando termines, tu terminal debería lucir así:
 :x: Si no, por favor **pídele ayuda a un profesor**.
 
 
+## Conexión de tu navegador predeterminado con Ubuntu
+
+Para asegurarnos de que puedas interactuar desde la terminal de Ubuntu con el navegador que tienes instalado en Windows, debemos definirlo como tu navegador predeterminado aquí.
+
+:warning: Tienes que ejecutar al menos uno de los siguientes comandos:
+
+<details>
+  <summary>Google Chrome como tu navegador predeterminado</summary>
+
+  Ejecuta este comando:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+  Si obtienes un error como este `ls: cannot access...` corre el siguiente comando:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  Si no es el caso, ejecuta lo siguiente:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Mozilla Firefox como tu navegador predeterminado</summary>
+
+  Ejecuta el siguiente comando:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  Si obtienes un error como este `ls: cannot access...` corre el siguiente comando:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  Si no es el caso, ejecuta lo siguiente:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Microsoft Edge como tu navegador predeterminado</summary>
+
+  Ejecuta el siguiente comando:
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+Reinicia tu terminal.
+
+Luego asegúrate de que el siguiente comando devuelva "Browser defined 👌":
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+Si no lo hace pero
+
+:heavy_check_mark: sí obtienes este mensaje, puedes continuar :+1:
+
+:x: De lo contrario, escoge un navegador de la lista de arriba y ejecuta el comando correspondiente. Luego no olvides reiniciar tu terminal:
+
+```bash
+exec zsh
+```
+
+No dudes en **pedirle ayuda a tu profesor**.
+
+
 ## GitHub CLI
 
 CLI es una abreviación de [Command-line Interface](https://en.wikipedia.org/wiki/Command-line_interface) que significa interfaz de línea de comando.

--- a/windows.fr.md
+++ b/windows.fr.md
@@ -614,6 +614,87 @@ Si tu vois apparaître la question « Do you want to change your default shell 
 :x: Sinon, **demande au prof**
 
 
+## Associer ton navigateur par défaut à Ubuntu
+
+Pour que tu puisses interagir avec le navigateur installé sous Windows depuis ton terminal Ubuntu, on doit le définir comme navigateur par défaut.
+
+:warning: Tu dois exécuter au moins une des commandes ci-dessous :
+
+<details>
+ <summary>Google Chrome est ton navigateur par défaut</summary>
+
+Exécute la commande :
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+Si tu obtiens une erreur du type `ls: cannot access...`, exécute la commande suivante :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  Sinon, exécute :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+ <summary>Mozilla Firefox est ton navigateur par défaut</summary>
+
+  Exécute la commande :
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  Si tu obtiens une erreur du type `ls: cannot access...`, exécute la commande suivante :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  Sinon, exécute :
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+ <summary>Microsoft Edge est ton navigateur par défaut</summary>
+
+  Exécute la commande :
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+Redémarre ton terminal.
+
+Puis vérifie que la commande suivante renvoie « Browser defined 👌 » :
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+Si ce n’est pas le cas,
+
+:heavy_check_mark: Si tu vois apparaître ce message, tu peux continuer :+1:
+
+:x: Sinon, choisis un navigateur dans la liste ci-dessus et exécute la commande correspondante. Puis n’oublie pas de réinitialiser ton terminal :
+
+```bash
+exec zsh
+```
+
+N’hésite pas à **demander au prof**.
+
+
 ## GitHub CLI
 
 CLI est l’acronyme de [Command-line Interface](https://en.wikipedia.org/wiki/Command-line_interface), interface en ligne de commande.

--- a/windows.md
+++ b/windows.md
@@ -620,6 +620,87 @@ At the end your terminal should look like this:
 :x: Otherwise, please **ask for a teacher**
 
 
+## Linking your default browser to Ubuntu
+
+To be sure that you can interact with your browser installed on Windows from your Ubuntu terminal, we need to set it as your default browser there.
+
+:warning: You need to execute at least one of the following commands below:
+
+<details>
+  <summary>Google Chrome as your default browser</summary>
+
+  Run the command:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
+  ```
+
+  If you get an error like `ls: cannot access...` Run the following command:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+
+  Else run:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Mozilla Firefox as your default browser</summary>
+
+  Run the command:
+
+  ```bash
+    ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
+  ```
+
+  If you get an error like `ls: cannot access...` Run the following command:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+
+  Else run:
+
+  ```bash
+    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+<details>
+  <summary>Microsoft Edge as your default browser</summary>
+
+  Run the command:
+
+  ```bash
+  echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+  ```
+</details>
+
+Restart your terminal.
+
+Then please make sure that the following command returns "Browser defined 👌":
+
+```bash
+[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"
+```
+
+If it does not,
+
+:heavy_check_mark: If you got this message, you can continue :+1:
+
+:x: If not, choose a browser in the list above and execute the corresponding command. Then don't forget to reset your terminal:
+
+```bash
+exec zsh
+```
+
+Do not hesitate to **contact a teacher**.
+
+
 ## GitHub CLI
 
 CLI is the acronym of [Command-line Interface](https://en.wikipedia.org/wiki/Command-line_interface).


### PR DESCRIPTION
@krokrob suggested the web setup will probably encounter the same issue as the latest data setup https://github.com/lewagon/data-setup/pull/225 : the latest version of Ubuntu 22.04 does not allow to open URLs from the CLI using the windows browser unless the `BROWSER` environment variable is defined

the suggested solution is to have the students configure it