### PR TITLE
update WinTerm instructions

### DIFF
--- a/_partials/windows_terminal.md
+++ b/_partials/windows_terminal.md
@@ -45,7 +45,7 @@ It should open the terminal settings:
 - Click on "Save"
 - Click on "Open JSON file"
 
-You may see an orange circle rather than a penguin as the logo for Ubuntu
+You may see an orange circle rather than a penguin as the logo for Ubuntu.
 
 We have circle in red the part you will change:
 

--- a/_partials/windows_terminal.md
+++ b/_partials/windows_terminal.md
@@ -45,12 +45,14 @@ It should open the terminal settings:
 - Click on "Save"
 - Click on "Open JSON file"
 
+You may see an orange circle rather than a penguin as the logo for Ubuntu
+
 We have circle in red the part you will change:
 
 ![Windows Terminal JSON settings file](images/windows_terminal_settings_json.png)
 
 First, let's ask Ubuntu to start directly inside your Ubuntu Home Directory instead of the Windows one:
-- Locate the `"name": "Ubuntu",`
+- Locate the entry with both `"name": "Ubuntu",` and `"hidden": false,`
 - Add the following line after it:
 
 ```bash


### PR DESCRIPTION
Update instructions for Windows Terminal

Ubuntu 22.04 is now the default provided by the MSFT Store under the name Ubuntu

This changes the logo of Ubuntu in WinTerminal from our beloved Tux to the orange circle of Ubuntu.
Also it causes the distro to be present 2 times in the json config file, one of them having hidden=true

- Add a warning telling students that they may see a penguin or orange circle as logo
- Update instructions to ask students to make modification in config file for the Ubuntu entry having hidden=false
