### PR TITLE
 improved format of windows browser section #434 

### DIFF
--- a/_partials/windows_browser.md
+++ b/_partials/windows_browser.md
@@ -112,3 +112,4 @@ exec zsh
 ```
 
 Do not hesitate to **contact a teacher**.
+

--- a/_partials/windows_browser.md
+++ b/_partials/windows_browser.md
@@ -13,19 +13,32 @@ To be sure that you can interact with your browser installed on Windows from you
     ls /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
   ```
 
-  If you get an error like `ls: cannot access...` Run the following commands:
+  Did you get an error like `ls: cannot access...`?
+
+<details>
+  <summary>Yes, I had an error</summary>
+
+Run the following commands:
 
   ```bash
     echo "export BROWSER=\"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files/Google/Chrome/Application/chrome.exe'\"" >> ~/.zshrc
   ```
+</details>
 
-  Else run:
+<details>
+  <summary>No, everything was fine</summary>
+
+  Run the following commands:
 
   ```bash
     echo "export BROWSER=\"/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'\"" >> ~/.zshrc
   ```
+</details>
+
+---
+
 </details>
 
 <details>
@@ -37,19 +50,33 @@ To be sure that you can interact with your browser installed on Windows from you
     ls /mnt/c/Program\ Files\ \(x86\)/Mozilla\ Firefox/firefox.exe
   ```
 
-  If you get an error like `ls: cannot access...` Run the following commands:
+  Did you get an error like `ls: cannot access...`?
+
+<details>
+  <summary>Yes, I had an error</summary>
+
+  Run the following commands:
 
   ```bash
     echo "export BROWSER=\"/mnt/c/Program Files/Mozilla Firefox/firefox.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files/Mozilla Firefox/firefox.exe'\"" >> ~/.zshrc
   ```
 
-  Else run:
+</details>
+
+<details>
+  <summary>No, everything was fine</summary>
+
+  Run the following commands:
 
   ```bash
     echo "export BROWSER=\"/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Mozilla Firefox/firefox.exe'\"" >> ~/.zshrc
   ```
+</details>
+
+---
+
 </details>
 
 <details>
@@ -61,6 +88,9 @@ To be sure that you can interact with your browser installed on Windows from you
     echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'\"" >> ~/.zshrc
   ```
+
+---
+
 </details>
 
 Restart your terminal.


### PR DESCRIPTION
This is related to https://github.com/lewagon/setup/issues/430

During Windows Setup Day we regularly encountered issues with the Linking your default browser to Ubuntu section. I did not change the content of this section but improved the format. Each section now has a nested collapsable menu which asks the student if they encountered an issue. This hopefully solves the recurring problem that students execute both command blocks.

This is how it looks now:
---
Linking your default browser to Ubuntu

To be sure that you can interact with your browser installed on Windows from your Ubuntu terminal, we need to set it as your default browser there.

⚠️ You need to execute at least one of the following commands below:
Google Chrome as your default browser
Mozilla Firefox as your default browser
Microsoft Edge as your default browser

Restart your terminal.

Then please make sure that the following command returns "Browser defined 👌":

[ -z "$BROWSER" ] && echo "ERROR: please define a BROWSER environment variable ⚠️" || echo "Browser defined 👌"

If it does not,

✔️ If you got this message, you can continue 👍

❌ If not, choose a browser in the list above and execute the corresponding command. Then don't forget to reset your terminal:

exec zsh

Do not hesitate to contact a teacher.