### PR TITLE
replace 'colored' gem with 'colorized'

### DIFF
--- a/macos.md
+++ b/macos.md
@@ -493,7 +493,7 @@ In the ruby world, we call external libraries `gems`: they are pieces of ruby co
 In your terminal, copy-paste the following command:
 
 ```bash
-gem install colored faker http pry-byebug rake rails rest-client rspec rubocop-performance sqlite3
+gem install colorize faker http pry-byebug rake rails rest-client rspec rubocop-performance sqlite3
 ```
 
 :heavy_check_mark: If you get `xx gems installed`, then all good :+1:


### PR DESCRIPTION
replace outdated 'colored' gem (updated 14Y ago) with a newer one ->
[https://github.com/fazibear/colorize](https://github.com/fazibear/colorize)

Original gem link 
https://github.com/defunkt/colored
