### PR TITLE
add libyaml-dev

### DIFF
--- a/_partials/macos_rbenv.md
+++ b/_partials/macos_rbenv.md
@@ -29,5 +29,5 @@ exec zsh
 Then run:
 
 ```bash
-brew install rbenv
+brew install rbenv libyaml
 ```

--- a/_partials/rbenv.md
+++ b/_partials/rbenv.md
@@ -14,7 +14,7 @@ rm -rf ~/.rbenv
 Then in the terminal, run:
 
 ```bash
-sudo apt install -y build-essential tklib zlib1g-dev libssl-dev libffi-dev libxml2 libxml2-dev libxslt1-dev libreadline-dev
+sudo apt install -y build-essential tklib zlib1g-dev libssl-dev libffi-dev libxml2 libxml2-dev libxslt1-dev libreadline-dev libyaml-dev
 ```
 
 ```bash


### PR DESCRIPTION
Would it be possible to integrate this command into the setup for both Windows and Ubuntu?
`apt install libyaml-dev
`We could include it in the rbenv section (part: `apt install)`.
This would eliminate issues with the psych gem.