### PR TITLE
Mention that `sudo -u postgres` throws an error

### DIFF
--- a/_partials/windows_postgresql.md
+++ b/_partials/windows_postgresql.md
@@ -18,12 +18,7 @@ sudo /etc/init.d/postgresql start
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb superuser;"
 ```
 
-<details>
-
-If you get an error saying `could not change directory to "/home/your_name": Permission denied` that is fine.
-If on the first run it says `CREATE ROLE` in the end all worked fine.
-
-</details>
+_📝 If you get an error saying `could not change directory to "/home/your_name": Permission denied` that is totally fine, and there's no need to worry 💆 If, on the first run, it says `CREATE ROLE` in the end all worked fine._
 
 You can configure PostgreSQL to autostart, so you don't have to execute `sudo /etc/init.d/postgresql start` each time you open a new terminal:
 

--- a/_partials/windows_postgresql.md
+++ b/_partials/windows_postgresql.md
@@ -18,6 +18,13 @@ sudo /etc/init.d/postgresql start
 sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb superuser;"
 ```
 
+<details>
+
+If you get an error saying `could not change directory to "/home/your_name": Permission denied` that is fine.
+If on the first run it says `CREATE ROLE` in the end all worked fine.
+
+</details>
+
 You can configure PostgreSQL to autostart, so you don't have to execute `sudo /etc/init.d/postgresql start` each time you open a new terminal:
 
 ```bash


### PR DESCRIPTION
Running ```sudo -u postgres psql --command "CREATE ROLE \"`whoami`\" LOGIN createdb superuser;"``` in the users home folder within ubuntu WSL throws the following error

```
could not change directory to "/home/student_name": Permission denied
```

The student doing the setup is expeceted to be in his /home/username folder. Which on WSL ubuntu by default is not accessible to other users on the system. So when the `su` command switches user, the postgres user can not access the current directory and that is throwing the permission error.

Which is fine because it does not have to access the current folder at all. It just has to connect to the postgres database which usually works. So the permission warning is followed by the success output `CREATE ROLE`.

This might not be obvious to someone following the setup for the first time. To reduce useless debugging there is now a note hidden in a spoiler that says that this error is okay.
