### PR TITLE
Fix Rails version for now

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -4,7 +4,7 @@ PLACEHOLDERS = {
   'RUBY_SETUP_VERSION' => "3.1.2",
   'NVM_VERSION' => "0.39.1",
   'NODE_VERSION' => "16.15.1",
-  'GEMS' => "colored faker http pry-byebug rake rails rest-client rspec rubocop-performance sqlite3:1.7.3 activerecord:7.1.3.2"
+  'GEMS' => "colored faker http pry-byebug rake rails:7.1.3.4 rest-client rspec rubocop-performance sqlite3:1.7.3 activerecord:7.1.3.2"
 }
 
 MACOS = %w[


### PR DESCRIPTION
Seems like if students install rails 7.2.1, it creates issues with
sqlite3 and activerecord support, and I haven't been able to find a
solution for that (I'm pretty sure the latest versions of those gems
just aren't compatible). So, the best approach I can think of for now is
to fix our `rails` version. Also, to be perfectly honest, I don't love
the idea that periodic Rails upgrades can break our whole setup, so I
think this is also probably just a good idea anyway. But yeah, it is a
bit of a hack and will require us periodically upgrading the version
manually ourselves.

Also part of my wonders if I should upgrade the install command in that
first Rails lecture, but I don't think students ever end up needing to
run it, and it's after the DB unit anyway, so I think it should be fine.
