### PR TITLE
[Important PR~not to merge without deployment plan] Upgrade to Node 20

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -3,7 +3,7 @@
 PLACEHOLDERS = {
   'RUBY_SETUP_VERSION' => "3.1.2",
   'NVM_VERSION' => "0.39.1",
-  'NODE_VERSION' => "16.15.1",
+  'NODE_VERSION' => "20.17.0",
   'GEMS' => "colored faker http pry-byebug rake rails:7.1.3.4 rest-client rspec rubocop-performance sqlite3:1.7.3 activerecord:7.1.3.2"
 }
 


### PR DESCRIPTION
resolve https://github.com/lewagon/setup/issues/441

I did a pretty exhaustive look through our repos, and as far as I can tell, I actually don't think upgrading `node` will change so much stuff!

I changed the version here in `setup`. Then, in `fullstack-challenges`, I added an `.nvmrc` file for those with it set up to change their version with `nvm` automatically. And I did the same in `fullstack-solutions` and then went into every single challenge in the JS units and ran `rake` to make sure they still raked green, ran `serve` to check the result myself, and ran `eslint --fix *` to improve the style.

But, given that the students really never use `node` during the challenges, I actually don't think this should affect much. And, we don't use `node` in Rails anymore, so I don't think it should affect any of the rails lectures or any of our Rails-related repos, agreed?

I feel like there should be more to do or something...but I think this is actually everything?

related:
- https://github.com/lewagon/fullstack-challenges/pull/2714
- https://github.com/lewagon/fullstack-solutions/pull/320