### PR TITLE
Version 3.3.5 does not end with p

### DIFF
--- a/_partials/cn/ruby.md
+++ b/_partials/cn/ruby.md
@@ -23,7 +23,7 @@ exec zsh
 ruby -v
 ```
 
-:heavy_check_mark: 如果你有看到`ruby <RUBY_SETUP_VERSION>p`，那么你可以继续下一步+1:
+:heavy_check_mark: 如果你有看到`ruby <RUBY_SETUP_VERSION>`，那么你可以继续下一步+1:
 
 :x: 如果没有的话，**询问一下老师**。
 

--- a/_partials/es/ruby.md
+++ b/_partials/es/ruby.md
@@ -28,7 +28,7 @@ Luego ejecuta esto:
 ruby -v
 ```
 
-:heavy_check_mark: Si ves algo que comience por `ruby <RUBY_SETUP_VERSION>p`, entonces puedes continuar +1:
+:heavy_check_mark: Si ves algo que comience por `ruby <RUBY_SETUP_VERSION>`, entonces puedes continuar +1:
 
 :x: Si no es el caso, **pídele ayuda a un profesor**.
 

--- a/_partials/fr/ruby.md
+++ b/_partials/fr/ruby.md
@@ -29,7 +29,7 @@ Puis exécute :
 ruby -v
 ```
 
-:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby <RUBY_SETUP_VERSION>p`, tu peux continuer :+1:
+:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby <RUBY_SETUP_VERSION>`, tu peux continuer :+1:
 
 :x: Sinon, **demande au prof**
 

--- a/_partials/pt/ruby.md
+++ b/_partials/pt/ruby.md
@@ -29,7 +29,7 @@ Então corra:
 ruby -v
 ```
 
-:heavy_check_mark: Se você vir algo começando com `ruby <RUBY_SETUP_VERSION>p` então você pode prosseguir :+1:
+:heavy_check_mark: Se você vir algo começando com `ruby <RUBY_SETUP_VERSION>` então você pode prosseguir :+1:
 
 :x: Se não, **pergunte a um professor**
 

--- a/_partials/ruby.md
+++ b/_partials/ruby.md
@@ -29,7 +29,7 @@ Then run:
 ruby -v
 ```
 
-:heavy_check_mark: If you see something starting with `ruby <RUBY_SETUP_VERSION>p` then you can proceed :+1:
+:heavy_check_mark: If you see something starting with `ruby <RUBY_SETUP_VERSION>` then you can proceed :+1:
 
 :x: If not, **ask a teacher**
 

--- a/macos.cn.md
+++ b/macos.cn.md
@@ -402,7 +402,7 @@ exec zsh
 ruby -v
 ```
 
-:heavy_check_mark: 如果你有看到`ruby 3.3.5p`，那么你可以继续下一步+1:
+:heavy_check_mark: 如果你有看到`ruby 3.3.5`，那么你可以继续下一步+1:
 
 :x: 如果没有的话，**询问一下老师**。
 

--- a/macos.es.md
+++ b/macos.es.md
@@ -427,7 +427,7 @@ Luego ejecuta esto:
 ruby -v
 ```
 
-:heavy_check_mark: Si ves algo que comience por `ruby 3.3.5p`, entonces puedes continuar +1:
+:heavy_check_mark: Si ves algo que comience por `ruby 3.3.5`, entonces puedes continuar +1:
 
 :x: Si no es el caso, **pídele ayuda a un profesor**.
 

--- a/macos.fr.md
+++ b/macos.fr.md
@@ -424,7 +424,7 @@ Puis exécute :
 ruby -v
 ```
 
-:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby 3.3.5p`, tu peux continuer :+1:
+:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby 3.3.5`, tu peux continuer :+1:
 
 :x: Sinon, **demande au prof**
 

--- a/macos.md
+++ b/macos.md
@@ -467,7 +467,7 @@ Then run:
 ruby -v
 ```
 
-:heavy_check_mark: If you see something starting with `ruby 3.3.5p` then you can proceed :+1:
+:heavy_check_mark: If you see something starting with `ruby 3.3.5` then you can proceed :+1:
 
 :x: If not, **ask a teacher**
 

--- a/macos.pt.md
+++ b/macos.pt.md
@@ -466,7 +466,7 @@ Então corra:
 ruby -v
 ```
 
-:heavy_check_mark: Se você vir algo começando com `ruby 3.3.5p` então você pode prosseguir :+1:
+:heavy_check_mark: Se você vir algo começando com `ruby 3.3.5` então você pode prosseguir :+1:
 
 :x: Se não, **pergunte a um professor**
 

--- a/ubuntu.cn.md
+++ b/ubuntu.cn.md
@@ -378,7 +378,7 @@ exec zsh
 ruby -v
 ```
 
-:heavy_check_mark: 如果你有看到`ruby 3.3.5p`，那么你可以继续下一步+1:
+:heavy_check_mark: 如果你有看到`ruby 3.3.5`，那么你可以继续下一步+1:
 
 :x: 如果没有的话，**询问一下老师**。
 

--- a/ubuntu.es.md
+++ b/ubuntu.es.md
@@ -401,7 +401,7 @@ Luego ejecuta esto:
 ruby -v
 ```
 
-:heavy_check_mark: Si ves algo que comience por `ruby 3.3.5p`, entonces puedes continuar +1:
+:heavy_check_mark: Si ves algo que comience por `ruby 3.3.5`, entonces puedes continuar +1:
 
 :x: Si no es el caso, **pídele ayuda a un profesor**.
 

--- a/ubuntu.fr.md
+++ b/ubuntu.fr.md
@@ -401,7 +401,7 @@ Puis exécute :
 ruby -v
 ```
 
-:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby 3.3.5p`, tu peux continuer :+1:
+:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby 3.3.5`, tu peux continuer :+1:
 
 :x: Sinon, **demande au prof**
 

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -441,7 +441,7 @@ Then run:
 ruby -v
 ```
 
-:heavy_check_mark: If you see something starting with `ruby 3.3.5p` then you can proceed :+1:
+:heavy_check_mark: If you see something starting with `ruby 3.3.5` then you can proceed :+1:
 
 :x: If not, **ask a teacher**
 

--- a/ubuntu.pt.md
+++ b/ubuntu.pt.md
@@ -440,7 +440,7 @@ Então corra:
 ruby -v
 ```
 
-:heavy_check_mark: Se você vir algo começando com `ruby 3.3.5p` então você pode prosseguir :+1:
+:heavy_check_mark: Se você vir algo começando com `ruby 3.3.5` então você pode prosseguir :+1:
 
 :x: Se não, **pergunte a um professor**
 

--- a/windows.cn.md
+++ b/windows.cn.md
@@ -911,7 +911,7 @@ exec zsh
 ruby -v
 ```
 
-:heavy_check_mark: 如果你有看到`ruby 3.3.5p`，那么你可以继续下一步+1:
+:heavy_check_mark: 如果你有看到`ruby 3.3.5`，那么你可以继续下一步+1:
 
 :x: 如果没有的话，**询问一下老师**。
 

--- a/windows.es.md
+++ b/windows.es.md
@@ -934,7 +934,7 @@ Luego ejecuta esto:
 ruby -v
 ```
 
-:heavy_check_mark: Si ves algo que comience por `ruby 3.3.5p`, entonces puedes continuar +1:
+:heavy_check_mark: Si ves algo que comience por `ruby 3.3.5`, entonces puedes continuar +1:
 
 :x: Si no es el caso, **pídele ayuda a un profesor**.
 

--- a/windows.fr.md
+++ b/windows.fr.md
@@ -934,7 +934,7 @@ Puis exécute :
 ruby -v
 ```
 
-:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby 3.3.5p`, tu peux continuer :+1:
+:heavy_check_mark: Si tu vois apparaître un message commençant par `ruby 3.3.5`, tu peux continuer :+1:
 
 :x: Sinon, **demande au prof**
 

--- a/windows.md
+++ b/windows.md
@@ -993,7 +993,7 @@ Then run:
 ruby -v
 ```
 
-:heavy_check_mark: If you see something starting with `ruby 3.3.5p` then you can proceed :+1:
+:heavy_check_mark: If you see something starting with `ruby 3.3.5` then you can proceed :+1:
 
 :x: If not, **ask a teacher**
 

--- a/windows.pt.md
+++ b/windows.pt.md
@@ -991,7 +991,7 @@ Então corra:
 ruby -v
 ```
 
-:heavy_check_mark: Se você vir algo começando com `ruby 3.3.5p` então você pode prosseguir :+1:
+:heavy_check_mark: Se você vir algo começando com `ruby 3.3.5` então você pode prosseguir :+1:
 
 :x: Se não, **pergunte a um professor**
 


### PR DESCRIPTION
``ruby -v`` used to say 3.1.2p in the old version now it only says 3.3.5