### PR TITLE
Align Windows 11 and 10 WSL installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build setup guides
 on:
   push:
+    branches:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,6 @@
 name: Build setup guides
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, synchronize]
-    branches:
-      - "master*"
-      - "main*"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - "master*"
+      - "main*"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/_partials/es/windows_terminal.md
+++ b/_partials/es/windows_terminal.md
@@ -6,8 +6,10 @@
 
 Si estás utilizando Windows 11, la terminal de Windows ya está instalada y puedes ir a la siguiente sección :point_down:
 
+Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal moderna.
 
-Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal moderna:
+<details>
+<summary>**Windows 10**: Instalar Windows Terminal</summary>
 
 - Haz clic en `Start`
 - Escribe `Microsoft Store`
@@ -31,6 +33,8 @@ Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal
 </details>
 
 Cuando termine la instalación, el botón `Install` se transformará en un botón `Launch`: haz clic en él.
+
+</details>
 
 ### Ubuntu como terminal predeterminada
 

--- a/_partials/es/windows_ubuntu.md
+++ b/_partials/es/windows_ubuntu.md
@@ -2,13 +2,13 @@
 
 ### Instalación
 
-:information_source: Las instrucciones que verás a continuación dependen de la versión de Windows que tengas. Por favor solo sigue las instrucciones que correspondan a tu versión de Windows :point_down:
+Después de reiniciar tu computadora, deberías ver una ventana de terminal diciendo WSL está retomando el proceso de instalación de Ubuntu. Cuando termine, iniciará Ubuntu.
 
-#### Windows 11
+<details>
+<summary>Solución de problemas para Windows 10 (solo si es necesario, consulta con un profesor)</summary>
 
-Si estás utilizando Windows 11, después de reiniciar tu computadora, deberías ver una ventana de terminal diciendo WSL está retomando el proceso de instalación de Ubuntu. Cuando termine, iniciará Ubuntu.
-
-#### Windows 10
+Si la instalación de Ubuntu no se reanudó, primero intenta nuevamente: abre Powershell o el Símbolo del sistema y ejecuta `wsl --install` otra vez.
+</details>
 
 Si tienes Windows 10, instala la terminal de Windows por medio de la Microsoft Store:
 
@@ -34,6 +34,8 @@ Si tienes Windows 10, instala la terminal de Windows por medio de la Microsoft S
 
 Cuando termine la instalación, el botón `Get` se transformará en un botón `Open`: Haz clic en él.
 
+</details>
+
 ### Primer uso
 
 La primera vez que lo abras, te pedirán que:
@@ -46,8 +48,6 @@ La primera vez que lo abras, te pedirán que:
 - Confírmalo
 
 :warning: Cuando escribas tu contraseña no verás nada en la pantalla. **Esto es normal**. Es una herramienta de seguridad para ocultar tanto el contenido de tu contraseña como su longitud. Simplemente escribe tu contraseña y presiona `Enter` al terminar.
-
-Ahora puedes cerrar la ventana de Ubuntu ya que está instalado en tu computadora.
 
 ### Chequea la versión WSL de Ubuntu
 
@@ -77,7 +77,6 @@ wsl -l -v
   :heavy_check_mark: Deberías obtener el siguiente mensaje en algunos segundos: `The conversion is complete`. Esto significa que la conversión ha sido completada.
 
   :x: Si no funciona, tendremos que asegurarnos de que los archivos de Ubuntu no estén comprimidos.
-</details>
 
 <details>
   <summary>Chequea si los archivos no están comprimidos</summary>
@@ -96,7 +95,23 @@ wsl -l -v
   :x: Si la conversión aún no funciona, por favor **contacta a un profesor**.
 </details>
 
-### Compruebe la locale
+Ya puedes cerrar la ventana de la terminal.
+
+</details>
+
+### Comprueba tu nombre de usuario
+
+Escribe esto en la terminal de Ubuntu:
+
+```bash
+whoami
+```
+
+Debería devolver el nombre de usuario que elegiste anteriormente.
+
+:x: Si dice `root`, **contacta a un profesor** antes de continuar.
+
+### Comprueba la configuración regional (locale)
 
 La "locale" es un mecanismo que permite adaptar los programas a su idioma y país.
 
@@ -125,5 +140,3 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-Ya puedes cerrar la ventana de la terminal.

--- a/_partials/es/windows_version.md
+++ b/_partials/es/windows_version.md
@@ -11,25 +11,16 @@ Para chequear la versión de tu Windows:
 - Escribe  `winver`
 - Presiona `Enter`
 
-:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10 o Windows 11**, entonces todo está bien y puedes continuar trabajando en la configuración :+1:
+:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 11**, entonces todo está bien y puedes continuar trabajando en la configuración :+1:
 
-:x: Si no es el caso, no puedes continuar. Primero debes actualizar tu versión a Windows 10 :point_down:
+:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10**, verifica el **número de la versión**:
+
+:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+
+:x: Si es inferior a `2004`, debes actualizar tu versión.
 
 <details>
-  <summary>Actualizar a Windows 10</summary>
-
-  - Descarga Windows 10 desde [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-  - Instálalo. Debería tomar como una hora pero realmente depende de tu computadora.
-  - Cuando termine la instalación, ejecuta los comandos de aquí arriba :point_up: para chequear que tengas **Windows 10**.
-</details>
-
-:information_source: [La actualización de Windows 11 está en curso en este momento](https://www.microsoft.com/en-us/windows/get-windows-11). Esto significa que puede que esté o que aún no esté disponible para tu computadora.
-
-:warning: **Si tienes Windows 10 instalado, no necesitas actualizarlo a Windows 11 para hacer esta configuración**.
-
-### Últimas actualizaciones
-
-Una vez que estés seguro de que estés usando Windows 10 o 11, instala las siguientes actualizaciones.
+  <summary>Últimas actualizaciones</summary>
 
 Abre Windows Update:
 - Presiona `Windows` + `R`
@@ -57,16 +48,14 @@ Abre Windows Update:
   ¡Ahora intenta instalar las actualizaciones nuevamente!
 </details>
 
-### Requisito mínimo para la versión
-
-Algunas de las herramientas que necesitamos han salido con la versión `1903` **o superior** de Windows 10, así que necesitamos asegurarnos de que al menos tengamos esa.
+Verifica el número de la versión:
 
 - Presiona `Windows` + `R`
 - Escribe  `winver`
 - Presiona `Enter`
 
-Verifica el **número de la versión**:
+:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
 
-:heavy_check_mark: Si dice al menos `1903`, entonces todo está bien :+1:
+:x: Si es inferior a `2004`, por favor **contacta a un profesor**.
 
-:x: Si es inferior a `1903`, por favor **contacta a un profesor**.
+</details>

--- a/_partials/es/windows_version.md
+++ b/_partials/es/windows_version.md
@@ -15,47 +15,47 @@ Para chequear la versión de tu Windows:
 
 :heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10**, verifica el **número de la versión**:
 
-:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+- :heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
 
-:x: Si es inferior a `2004`, debes actualizar tu versión.
+- :x: Si es inferior a `2004`, debes actualizar tu versión.
 
-<details>
-  <summary>Últimas actualizaciones</summary>
+- <details>
+  <summary>Cómo instalar las últimas actualizaciones?</summary>
 
-Abre Windows Update:
-- Presiona `Windows` + `R`
-- Escribe `ms-settings:windowsupdate`
-- Presiona `Enter`
-- Haz clic en `Check updates`
-
-:heavy_check_mark: Si tienes una marca verde y el siguiente mensaje "You're up to date", entonces todo está bien :+1:
-
-:warning: Si obtienes una exclamación roja y el siguiente mensaje "Update available", por favor instala las actualizaciones y repite el proceso hasta que diga que todo está actualizado :loop:
-
-:x: Si obtienes un mensaje de error diciendo que Windows no puede aplicar las actualizaciones, por favor **contacta a un profesor**.
-
-<details>
-  <summary>Activa Windows Update Service para resolver las Actualizaciones</summary>
-
-  Algunos antivirus y programas deshabilitan las actualizaciones que necesitamos y luego se muestra un error. ¡Solucionemos esto!
+  Abre Windows Update:
   - Presiona `Windows` + `R`
-  - Escribe `services.msc`
+  - Escribe `ms-settings:windowsupdate`
   - Presiona `Enter`
-  - Haz doble clic en `Windows Update Service`
-  - Coloca su `Startup` en `Automatic`
-  - Haz clic en `Start`
-  - Haz clic en `Ok`
-  ¡Ahora intenta instalar las actualizaciones nuevamente!
-</details>
+  - Haz clic en `Check updates`
 
-Verifica el número de la versión:
+  :heavy_check_mark: Si tienes una marca verde y el siguiente mensaje "You're up to date", entonces todo está bien :+1:
 
-- Presiona `Windows` + `R`
-- Escribe  `winver`
-- Presiona `Enter`
+  :warning: Si obtienes una exclamación roja y el siguiente mensaje "Update available", por favor instala las actualizaciones y repite el proceso hasta que diga que todo está actualizado :loop:
 
-:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+  :x: Si obtienes un mensaje de error diciendo que Windows no puede aplicar las actualizaciones, por favor **contacta a un profesor**.
 
-:x: Si es inferior a `2004`, por favor **contacta a un profesor**.
+  <details>
+    <summary>Activa Windows Update Service para resolver las Actualizaciones</summary>
 
-</details>
+    Algunos antivirus y programas deshabilitan las actualizaciones que necesitamos y luego se muestra un error. ¡Solucionemos esto!
+    - Presiona `Windows` + `R`
+    - Escribe `services.msc`
+    - Presiona `Enter`
+    - Haz doble clic en `Windows Update Service`
+    - Coloca su `Startup` en `Automatic`
+    - Haz clic en `Start`
+    - Haz clic en `Ok`
+    ¡Ahora intenta instalar las actualizaciones nuevamente!
+  </details>
+
+  Verifica el número de la versión:
+
+  - Presiona `Windows` + `R`
+  - Escribe  `winver`
+  - Presiona `Enter`
+
+  :heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+
+  :x: Si es inferior a `2004`, por favor **contacta a un profesor**.
+
+  </details>

--- a/_partials/es/windows_wsl.md
+++ b/_partials/es/windows_wsl.md
@@ -2,21 +2,17 @@
 
 WSL es el ambiente de entorno que estamos usando para usar Ubuntu. Puedes aprender más sobre WSL [aquí](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: Las instrucciones que verás a continuación dependen de la versión de Windows que tengas. Por favor ejecuta solamente las instrucciones que correspondan a tu versión :point_down:
+Instalaremos WSL 2 y Ubuntu con un comando a través de la Windows Command Prompt.
 
-### Windows 11
-
-Si usas Windows 11, instalaremos WSL 2 y Ubuntu con un comando a través de la terminal de Windows.
-
-:warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar la **terminal de Windows** con privilegios de administrador en lugar de simplemente hacer clic en `Ok` o presionar `Enter`.
+:warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar la **Windows Command Prompt** con privilegios de administrador en lugar de simplemente hacer clic en `Ok` o presionar `Enter`.
 
 - Presiona `Windows` + `R`
-- Escribe `wt`
+- Escribe `cmd`
 - Presiona **`Ctrl` + `Shift` + `Enter`**
 
 :warning: tal vez tengas que aceptar la confirmación UAC sobre el cambio en los privilegios.
 
-Un ventana de terminal azul aparecerá:
+Un ventana de terminal aparecerá:
 - Copia el siguiente comando (`Ctrl` + `C`)
 - Pégalo en la ventana de la terminal (`Ctrl` + `V` o haciendo clic derecho en la ventana)
 - Ejecútalo presionado `Enter`
@@ -29,11 +25,10 @@ wsl --install
 
 :x: Si obtienes un mensaje de error (o si ves algún texto en rojo en la ventana), por favor **contacta a un profesor**
 
-### Windows 10
+<details>
+<summary>Solución de problemas para Windows 10 (solo si es necesario, consulta con un profesor)</summary>
 
-#### Instalación de WSL 1
-
-Si tienes Windows 10, primero instalaremos WSL 1 por medio de la Terminal de PowerShell.
+#### Para Windows 10 < 2004: instala primero WSL 1
 
 :warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar **Windows PowerShell** con privilegios de administrador en lugar de hacer clic en `Ok` o presionar `Enter`.
 
@@ -64,7 +59,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: Si obtienes un mensaje de error (o si ves algún texto en rojo en la ventada), por favor **contacta a un profesor**
 
-#### Actualización a WSL 2
+#### Para Windows 10 con WSL 1: Actualización a WSL 2
 
 Si tienes Windows 10, actualizaremos WSL a la versión 2.
 
@@ -82,7 +77,7 @@ Cuando se reinicie tu computadora, descarga el instalador de WSL2.
 
 :x: Si obtienes el siguiente error "This update only applies to machines with the Windows Subsystem for Linux", **haz clic derecho** en el programa y selecciona `uninstall`; esta vez deberías poder instalarlo sin problemas.
 
-#### Coloca WSL 2 como el Subsistema Windows por defecto para Linux
+#### Para Windows 10 con WSL 1: Coloca WSL 2 como el Subsistema Windows por defecto para Linux
 
 Si tienes Windows 10, pondremos la versión predeterminada de WSL en 2.
 
@@ -113,4 +108,6 @@ wsl --set-default-version 2
   Sigue los pasos [siguientes](https://winaero.com/enable-use-hyper-v-windows-10/) hasta que hayas habilitado el grupo <strong>Hyper-V</strong>
 
   :information_source: Si tienes Windows 10 **Home edition**, la feature Hyper-V no está disponible para su sistema operativo. No es un bloqueo y puedes continuar con las siguientes instrucciones aquí abajo :ok_hand:
+</details>
+
 </details>

--- a/_partials/fr/windows_terminal.md
+++ b/_partials/fr/windows_terminal.md
@@ -6,7 +6,10 @@
 
 Si tu as Windows 11, le Windows Terminal est déjà installé et tu peux passer à la section suivante :point_down:
 
-Si tu as Windows 10, nous allons installer le Windows Terminal, un terminal vraiment moderne :
+Si tu as Windows 10, nous allons installer le Windows Terminal, un terminal vraiment moderne.
+
+<details>
+<summary><strong>Windows 10</strong>: Installer le Windows Terminal</summary>
 
 - Clique sur `Démarrer`
 - Saisis `Microsoft Store`
@@ -30,6 +33,8 @@ Si tu as Windows 10, nous allons installer le Windows Terminal, un terminal vrai
 </details>
 
 Une fois l’installation terminée, le bouton « Installer » se transforme en bouton « Lancer » ; clique dessus.
+
+</details>
 
 ### Définir Ubuntu comme terminal par défaut
 

--- a/_partials/fr/windows_ubuntu.md
+++ b/_partials/fr/windows_ubuntu.md
@@ -2,13 +2,12 @@
 
 ### Installation
 
-:information_source: Les instructions suivantes dépendent de ta version de Windows. N'exécute que les instructions qui correspondent à ta version :point_down:
-
-#### Windows 11
-
 Si tu as Windows 11, après avoir redémarré ton ordinateur, tu devrais voir une fenêtre de terminal indiquant que WSL poursuit le processus d'installation d'Ubuntu. Lorsque c'est terminé, Ubuntu va se lancer.
 
-#### Windows 10
+<details>
+<summary>Résolution des problèmes pour Windows 10 (uniquement si nécessaire, vérifie avec un TA)</summary>
+
+Si l'installation d'Ubuntu ne reprend pas, essaye d'abord à nouveau : relance Powershell ou l'Invite de commandes et exécute la commande `wsl --install` une nouvelle fois.
 
 Si tu as Windows 10, installons Ubuntu via le Microsoft Store :
 
@@ -33,6 +32,8 @@ Si tu as Windows 10, installons Ubuntu via le Microsoft Store :
 </details>
 
 Une fois l’installation terminée, le bouton « Installer » se transforme en bouton « Lancer » ; clique dessus.
+
+</details>
 
 ### Premier lancement
 
@@ -77,7 +78,6 @@ wsl -l -v
   :heavy_check_mark: Au bout de quelques secondes, tu devrais voir apparaître le message suivant : `The conversion is complete`.
 
   :x: Si ce n’est pas le cas, il faut vérifier que les fichiers Ubuntu ne sont pas compressés.
-</details>
 
 <details>
   <summary>Vérifier que les fichiers sont décompressés</summary>
@@ -96,11 +96,28 @@ wsl -l -v
   :x: Si la conversion ne fonctionne pas, **demande au prof**.
 </details>
 
+Tu peux maintenant fermer cette fenêtre de terminal.
+
+</details>
+
+### Vérifier ton nom d'utilisateur
+
+Tape cette commande dans le terminal Ubuntu :
+
+```bash
+whoami
+```
+
+Cela devrait renvoyer le nom d'utilisateur que tu as choisi précédemment.
+
+:x: Si cela affiche `root`, **contacte un TA** avant de continuer !
+
+
 ### Vérifier la locale
 
 Le concept e "locale" permert de personnaliser les programms en fonction de ta langue et ton pays.
 
-Vérifions que la locale est bien en **anglais** ans le terminal :
+Vérifions que la locale est bien en **anglais** dans le terminal :
 
 ```bash
 locale
@@ -125,5 +142,3 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-Tu peux maintenant fermer cette fenêtre de terminal.

--- a/_partials/fr/windows_version.md
+++ b/_partials/fr/windows_version.md
@@ -11,25 +11,16 @@ Pour connaître ta version de Windows :
 - Saisis `winver`
 - Appuie sur `Enter`
 
-:heavy_check_mark: Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10 ou Windows 11**, c’est bon :+1:
+:heavy_check_mark: Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 11**, c’est bon :+1:
 
-:x: Sinon, tu ne pourras pas utiliser cette configuration. Il faut que tu mettes à jour ton Windows à la version 10 :point_down:
+Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10**, vérifie numéro de version:
+
+:heavy_check_mark: Si la version indique au moins `2004`, c’est bon :+1:
+
+:x: Sinon, il faut que tu mettes à jour ton Windows.
 
 <details>
-  <summary>Mise à niveau vers Windows 10</summary>
-
-  - Télécharge Windows 10 depuis [Microsoft](https://www.microsoft.com/fr-fr/software-download/windows10)
-  - Installe-le. L’installation devrait prendre une heure environ, mais cela dépend de ton ordinateur
-  - Une fois l’installation terminée, exécute les commandes ci-dessus pour vérifier que tu es sous **Windows 10**
-</details>
-
-:information_source: [La mise à jour Windows 11 est toujours en cours de déploiement](https://www.microsoft.com/en-us/windows/get-windows-11), ce qui signifie qu'elle peut être disponible, ou pas, pour ton ordinateur.
-
-:warning: **Si tu as Windows 10 installé, tu n'as pas besoin de faire la mise à jour Windows 11 pour continuer cette configuration**.
-
-### Dernières mises à jour
-
-Une fois que tu as vérifié que tu utilises Windows 10 ou 11, tu vas devoir installer les dernières mises à jour.
+  <summary> Dernières mises à jour</summary>
 
 Ouvre Windows Update :
 - Appuie sur `Windows` + `R`
@@ -57,16 +48,15 @@ Ouvre Windows Update :
   On va maintenant réessayer d’effectuer les mises à jour.
 </details>
 
-### Version minimum
-
-Certains des outils qu’on doit installer sont compatibles avec la version `1903` **ou une version ultérieure** de Windows 10 ; on doit donc vérifier que tu as bien cette version au minimum.
+Vérifie le numéro de version :
 
 - Appuie sur `Windows` + `R`
 - Saisis `winver`
 - Appuie sur `Enter`
 
-Vérifie le **numéro de version** :
 
 :heavy_check_mark: Si la version indique au moins `1903`, c’est bon :+1:
 
 :x: S’il s’agit d’une version antérieure, **demande au prof**.
+
+</details>

--- a/_partials/fr/windows_version.md
+++ b/_partials/fr/windows_version.md
@@ -13,50 +13,50 @@ Pour connaître ta version de Windows :
 
 :heavy_check_mark: Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 11**, c’est bon :+1:
 
-Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10**, vérifie numéro de version:
+Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10**, vérifie le numéro de version:
 
-:heavy_check_mark: Si la version indique au moins `2004`, c’est bon :+1:
+- :heavy_check_mark: Si la version indique au moins `2004`, c’est bon :+1:
 
-:x: Sinon, il faut que tu mettes à jour ton Windows.
+- :x: Sinon, il faut que tu mettes à jour ton Windows.
 
-<details>
-  <summary> Dernières mises à jour</summary>
+- <details>
+  <summary>Comment installer les dernières mises à jour</summary>
 
-Ouvre Windows Update :
-- Appuie sur `Windows` + `R`
-- Saisis `ms-settings:windowsupdate`
-- Appuie sur `Enter`
-- Clique sur « Rechercher les mises à jour »
-
-:heavy_check_mark: Si tu vois apparaître une coche verte et le message « Vous êtes à jour », c’est bon :+1:
-
-:warning: Si tu vois apparaître un point d’exclamation rouge et le message « Mise à jour disponible », installe-la et recommence jusqu’à ce que le message « Vous êtes à jour » apparaisse :loop:
-
-:x: Si tu vois apparaître un message d’erreur indiquant que Windows ne peut pas appliquer les mises à jour, **demande au prof**.
-
-<details>
-  <summary>Activer le service Windows Update pour corriger les mises à jour</summary>
-
-  Certains antivirus et logiciels désactivent le service de mise à jour dont on a besoin, entraînant l’erreur que tu vois apparaître. On va corriger ça !
+  Ouvre Windows Update :
   - Appuie sur `Windows` + `R`
-  - Saisis `services.msc`
+  - Saisis `ms-settings:windowsupdate`
   - Appuie sur `Enter`
-  - Double-clique sur `Windows Update Service`
-  - Définis `Startup` sur `Automatic`
-  - Clique sur `Start`
-  - Clique sur `Ok`
-  On va maintenant réessayer d’effectuer les mises à jour.
-</details>
+  - Clique sur « Rechercher les mises à jour »
 
-Vérifie le numéro de version :
+  :heavy_check_mark: Si tu vois apparaître une coche verte et le message « Vous êtes à jour », c’est bon :+1:
 
-- Appuie sur `Windows` + `R`
-- Saisis `winver`
-- Appuie sur `Enter`
+  :warning: Si tu vois apparaître un point d’exclamation rouge et le message « Mise à jour disponible », installe-la et recommence jusqu’à ce que le message « Vous êtes à jour » apparaisse :loop:
+
+  :x: Si tu vois apparaître un message d’erreur indiquant que Windows ne peut pas appliquer les mises à jour, **demande au prof**.
+
+  <details>
+    <summary>Activer le service Windows Update pour corriger les mises à jour</summary>
+
+    Certains antivirus et logiciels désactivent le service de mise à jour dont on a besoin, entraînant l’erreur que tu vois apparaître. On va corriger ça !
+    - Appuie sur `Windows` + `R`
+    - Saisis `services.msc`
+    - Appuie sur `Enter`
+    - Double-clique sur `Windows Update Service`
+    - Définis `Startup` sur `Automatic`
+    - Clique sur `Start`
+    - Clique sur `Ok`
+    On va maintenant réessayer d’effectuer les mises à jour.
+  </details>
+
+  Vérifie le numéro de version :
+
+  - Appuie sur `Windows` + `R`
+  - Saisis `winver`
+  - Appuie sur `Enter`
 
 
-:heavy_check_mark: Si la version indique au moins `1903`, c’est bon :+1:
+  :heavy_check_mark: Si la version indique au moins `1903`, c’est bon :+1:
 
-:x: S’il s’agit d’une version antérieure, **demande au prof**.
+  :x: S’il s’agit d’une version antérieure, **demande au prof**.
 
-</details>
+  </details>

--- a/_partials/fr/windows_wsl.md
+++ b/_partials/fr/windows_wsl.md
@@ -2,21 +2,17 @@
 
 WSL est l’environnement de développement que l’on utilise pour exécuter Ubuntu. Pour en savoir plus sur WSL, [consulte cette page](https://docs.microsoft.com/fr-fr/windows/wsl/faq).
 
-:information_source: Les instructions suivantes dépendent de ta version de Windows. Exécute uniquement les instructions qui correspondent à ta version :point_down:
+Nous allons installer WSL 2 et Ubuntu en une seule commande via le Windows Command Prompt.
 
-### Windows 11
-
-Si tu as Windows 11, nous allons installer WSL 2 et Ubuntu en une seule commande via le Windows Terminal.
-
-:warning: Dans les instructions suivantes, utilise la combinaison de touches `Ctrl` + `Shift` + `Enter` pour exécuter **Windows Terminal** en tant qu’administrateur au lieu de cliquer simplement sur `Ok` ou d’appuyer sur `Enter`.
+:warning: Dans les instructions suivantes, utilise la combinaison de touches `Ctrl` + `Shift` + `Enter` pour exécuter **Windows Command Prompt** en tant qu’administrateur au lieu de cliquer simplement sur `Ok` ou d’appuyer sur `Enter`.
 
 - Appuie sur `Windows` + `R`
-- Saisis `wt`
+- Saisis `cmd`
 - Appuie sur **`Ctrl` + `Shift` + `Enter`**
 
 :warning: Tu devras peut-être accepter la confirmation UAC concernant l’octroi des droits d’administrateur.
 
-Une fenêtre de terminal bleue apparaîtra :
+Une fenêtre de terminal apparaîtra :
 - Copie la commande suivante (`Ctrl` + `C`)
 - Colle-la dans la fenêtre du terminal (`Ctrl` + `V` ou en faisant un clic droit dans la fenêtre)
 - Exécute-les en appuyant sur `Enter`
@@ -27,13 +23,12 @@ wsl --install
 
 :heavy_check_mark: Si la commande s’exécute sans erreur, redémarre ton ordinateur et suis les instructions ci-dessous :+1:
 
-:x: Si tu obtiens un message d’erreur (ou si tu vois apparaître du texte en rouge dans la fenêtre), **demande au prof**
+:x: Si tu obtiens un message d’erreur (ou si tu vois apparaître du texte en rouge dans la fenêtre), **demande au prof**.
 
-### Windows 10
+<details>
+<summary>Dépannage pour Windows 10 (uniquement si nécessaire, vérifie avec un professeur)</summary>
 
-#### Installer WSL 1
-
-Si tu as Windows 10, on va d'abord installer WSL 1 à partir du terminal PowerShell.
+#### Pour Windows 10 < 2004 : installer d'abord WSL 1
 
 :warning: Dans les instructions suivantes, utilise la combinaison de touches `Ctrl` + `Shift` + `Enter` pour exécuter **Windows PowerShell** en tant qu’administrateur au lieu de cliquer simplement sur `Ok` ou d’appuyer sur `Enter`.
 
@@ -64,7 +59,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: Si tu obtiens un message d’erreur (ou si tu vois apparaître du texte en rouge dans la fenêtre), **demande au prof**
 
-#### Mise à niveau vers WSL 2
+#### Pour Windows 10 avec WSL 1 : Mise à niveau vers WSL 2
 
 Si tu as Windows 10, on va maintenant mettre à jour WSL à la version 2.
 
@@ -82,7 +77,7 @@ Une fois que ton ordinateur a redémarré, on doit télécharger le programme d�
 
 :x: Si tu obtiens l’erreur « Cette mise à jour s’applique seulement aux machines avec le sous-système Windows pour Linux », **fais un clic droit** sur le programme et sélectionne `uninstall` ; tu devrais pouvoir l’installer normalement cette fois-ci.
 
-#### Définir WSL 2 comme sous-système Windows pour Linux par défaut
+#### Pour Windows 10 avec WSL 1 : Définir WSL 2 comme sous-système Windows pour Linux par défaut
 
 Si tu as Windows 10, on va enfin définir la version 2 de WSL comme étant la version par défaut.
 
@@ -113,4 +108,6 @@ wsl --set-default-version 2
   Suis les étapes décrites [ici](https://winaero.com/enable-use-hyper-v-windows-10/) pour activer le groupe <strong>Hyper-V</strong>
 
   :information_source: Si tu as Windows 10 **Home edition**, la fonction Hyper-V n'est pas disponible sur ton système d'exploitation. Ce n'est pas bloquant et tu peux continuer à suivre les instructions ci-dessous :ok_hand:
+</details>
+
 </details>

--- a/_partials/pt/windows_terminal.md
+++ b/_partials/pt/windows_terminal.md
@@ -6,7 +6,10 @@
 
 Se você estiver executando o Windows 11, o Terminal do Windows já está instalado e você pode prosseguir para a próxima seção :point_down:
 
-Se você estiver executando o Windows 10, vamos instalar o Windows Terminal, um terminal realmente moderno:
+Se você estiver executando o Windows 10, vamos instalar o Windows Terminal, um terminal realmente moderno.
+
+<details>
+<summary><strong>Windows 10</strong>: Instalar Windows Terminal</summary>
 
 - Clique em `Iniciar`
 - Digite `Microsoft Store`
@@ -30,6 +33,8 @@ Se você estiver executando o Windows 10, vamos instalar o Windows Terminal, um 
 </details>
 
 Assim que a instalação for concluída, o botão `Instalar` se torna um botão `Iniciar`: clique nele.
+
+</details>
 
 ### Ubuntu como terminal padrão
 

--- a/_partials/pt/windows_ubuntu.md
+++ b/_partials/pt/windows_ubuntu.md
@@ -2,13 +2,12 @@
 
 ### Instalação
 
-:information_source: As instruções a seguir dependem da sua versão do Windows. Por favor, execute apenas as instruções correspondentes à sua versão :point_down:
+Após reiniciar o computador, você deverá ver uma janela de terminal informando que o WSL está retomando o processo de instalação do Ubuntu. Quando terminar, o Ubuntu será lançado.
 
-#### Windows 11
+<details>
+<summary>Solução de problemas para Windows 10 (apenas se necessário, consulte um TA)</summary>
 
-Se você estiver executando o Windows 11, após reiniciar o computador, você deverá ver uma janela de terminal informando que o WSL está retomando o processo de instalação do Ubuntu. Quando terminar, o Ubuntu será lançado.
-
-#### Windows 10
+Se a instalação do Ubuntu não foi retomada, tente novamente: abra o Powershell ou o Prompt de Comando e execute `wsl --install` novamente.
 
 Se você estiver executando o Windows 10, vamos instalar o Ubuntu através da Microsoft Store:
 
@@ -96,6 +95,23 @@ wsl -l -v
    :x: Se a conversão ainda não funcionar, por favor **entre em contato com um professor**.
 </details>
 
+Agora você pode fechar esta janela do terminal.
+
+</details>
+
+### Check your username
+
+Type this in the Ubuntu terminal:
+
+```bash
+whoami
+```
+
+It should return the username you chose before.
+
+:x: It if says `root`, **contact a TA** before continuing!
+
+
 ### Verifique a localidade
 
 A localidade é um mecanismo que permite personalizar programas de acordo com seu idioma e país.
@@ -125,5 +141,3 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-Agora você pode fechar esta janela do terminal.

--- a/_partials/pt/windows_version.md
+++ b/_partials/pt/windows_version.md
@@ -11,25 +11,14 @@ Para verificar sua versão do Windows:
 - Digite `winver`
 - Pressione `Enter`
 
-:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10 ou Windows 11** você está pronto para prosseguir :+1:
+:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 11** você está pronto para prosseguir :+1:
 
-:x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar para o Windows 10 primeiro :point_down:
+:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10**, verifique o **Número da versão**::
+
+:x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar.
 
 <details>
-   <summary>Atualizar para o Windows 10</summary>
-
-   - Baixe o Windows 10 da [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-   - Instale-o. Deve demorar cerca de uma hora, mas isso depende do seu computador.
-   - Quando a instalação terminar, execute os comandos acima :point_up: para verificar se você agora tem o **Windows 10**.
-</details>
-
-:information_source: [A atualização do Windows 11 está sendo lançada agora](https://www.microsoft.com/en-us/windows/get-windows-11), o que significa que ela pode ou não estar disponível para o seu computador ainda .
-
-:warning: **Se você tiver o Windows 10 instalado, não será necessário atualizar para o Windows 11 para prosseguir com esta configuração**.
-
-### Ultimas atualizações
-
-Quando tiver certeza de que está usando o Windows 10 ou 11, você precisará instalar todas as atualizações mais recentes.
+   <summary>Ultimas atualizações</summary>
 
 Abra a atualização do Windows:
 - Pressione `Windows` + `R`
@@ -57,16 +46,16 @@ Abra a atualização do Windows:
    Então vamos tentar as atualizações novamente!
 </details>
 
-### Versão mínima
 
-Algumas das ferramentas que precisamos instalar foram lançadas com a versão `1903` **ou superior** do Windows 10, então precisamos ter certeza de que você tem pelo menos esta.
+Verifique o Número da versão:
 
 - Pressione `Windows` + `R`
 - Digite `winver`
 - Pressione `Enter`
 
-Verifique o **Número da versão**:
 
-:heavy_check_mark: Se disser pelo menos `1903`, você está pronto :+1:
+:heavy_check_mark: Se disser pelo menos `2004`, você está pronto :+1:
 
-:x: Se estiver abaixo de `1903`, por favor **entre em contato com um professor**.
+:x: Se estiver abaixo de `22004`, por favor **entre em contato com um professor**.
+
+</details>

--- a/_partials/pt/windows_version.md
+++ b/_partials/pt/windows_version.md
@@ -13,49 +13,49 @@ Para verificar sua versão do Windows:
 
 :heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 11** você está pronto para prosseguir :+1:
 
-:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10**, verifique o **Número da versão**::
+- :heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10**, verifique o **Número da versão**::
 
-:x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar.
+- :x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar.
 
-<details>
-   <summary>Ultimas atualizações</summary>
+- <details>
+  <summary>Como instalar as últimas atualizações?</summary>
 
-Abra a atualização do Windows:
-- Pressione `Windows` + `R`
-- Digite `ms-settings:windowsupdate`
-- Pressione `Enter`
-- Clique em `Verificar atualizações`
+  Abra a atualização do Windows:
+  - Pressione `Windows` + `R`
+  - Digite `ms-settings:windowsupdate`
+  - Pressione `Enter`
+  - Clique em `Verificar atualizações`
 
-:heavy_check_mark: Se você vir uma marca de seleção verde e a mensagem "Você está atualizado", você está pronto para prosseguir :+1:
+  :heavy_check_mark: Se você vir uma marca de seleção verde e a mensagem "Você está atualizado", você está pronto para prosseguir :+1:
 
-:warning: Se você tiver um ponto de exclamação vermelho e a mensagem "Atualização disponível", instale-os e repita o processo até que apareça que você está atualizado :loop:
+  :warning: Se você tiver um ponto de exclamação vermelho e a mensagem "Atualização disponível", instale-os e repita o processo até que apareça que você está atualizado :loop:
 
-:x: Se você receber uma mensagem de erro sobre o Windows não conseguir aplicar atualizações, **entre em contato com um professor**.
+  :x: Se você receber uma mensagem de erro sobre o Windows não conseguir aplicar atualizações, **entre em contato com um professor**.
 
-<details>
-   <summary>Ative o Windows Update Service para corrigir atualizações</summary>
+  <details>
+    <summary>Ative o Windows Update Service para corrigir atualizações</summary>
 
-   Alguns antivírus e softwares desativam o serviço de atualização de que precisamos, resultando no erro que você vê. Vamos consertar isso!
-   - Pressione `Windows` + `R`
-   - Digite `services.msc`
-   - Pressione `Enter`
-   - Clique duas vezes em `Serviço de atualização do Windows`
-   - Defina sua `Inicialização` para `Automático`
-   - Clique em `Iniciar`
-   - Clique em `Ok`
-   Então vamos tentar as atualizações novamente!
-</details>
-
-
-Verifique o Número da versão:
-
-- Pressione `Windows` + `R`
-- Digite `winver`
-- Pressione `Enter`
+    Alguns antivírus e softwares desativam o serviço de atualização de que precisamos, resultando no erro que você vê. Vamos consertar isso!
+    - Pressione `Windows` + `R`
+    - Digite `services.msc`
+    - Pressione `Enter`
+    - Clique duas vezes em `Serviço de atualização do Windows`
+    - Defina sua `Inicialização` para `Automático`
+    - Clique em `Iniciar`
+    - Clique em `Ok`
+    Então vamos tentar as atualizações novamente!
+  </details>
 
 
-:heavy_check_mark: Se disser pelo menos `2004`, você está pronto :+1:
+  Verifique o Número da versão:
 
-:x: Se estiver abaixo de `22004`, por favor **entre em contato com um professor**.
+  - Pressione `Windows` + `R`
+  - Digite `winver`
+  - Pressione `Enter`
 
-</details>
+
+  :heavy_check_mark: Se disser pelo menos `2004`, você está pronto :+1:
+
+  :x: Se estiver abaixo de `22004`, por favor **entre em contato com um professor**.
+
+  </details>

--- a/_partials/pt/windows_wsl.md
+++ b/_partials/pt/windows_wsl.md
@@ -2,21 +2,17 @@
 
 WSL é o ambiente de desenvolvimento que usamos para executar o Ubuntu. Você pode aprender mais sobre WSL [aqui](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: As instruções a seguir dependem da sua versão do Windows. Por favor, execute apenas as instruções correspondentes à sua versão :point_down:
+Instalaremos o WSL 2 e o Ubuntu em um comando através do Windows Command Prompt.
 
-### Windows 11
-
-Se você estiver executando o Windows 11, instalaremos o WSL 2 e o Ubuntu em um comando através do Terminal do Windows.
-
-:warning: Nas instruções a seguir, esteja ciente do pressionamento de tecla `Ctrl` + `Shift` + `Enter` para executar o **Terminal Windows** com privilégios de administrador em vez de apenas clicar em `Ok` ou pressionar `Enter` .
+:warning: Nas instruções a seguir, esteja ciente do pressionamento de tecla `Ctrl` + `Shift` + `Enter` para executar o **Windows Command Prompt** com privilégios de administrador em vez de apenas clicar em `Ok` ou pressionar `Enter` .
 
 - Pressione `Windows` + `R`
-- Digite `wt`
+- Digite `cmd`
 - Pressione **`Ctrl` + `Shift` + `Enter`**
 
 :warning: Você pode ter que aceitar a confirmação do UAC sobre a elevação de privilégio.
 
-Uma janela de terminal azul aparecerá:
+Uma janela de terminal aparecerá:
 - Copie o seguinte comando (`Ctrl` + `C`)
 - Cole-o na janela do terminal (`Ctrl` + `V` ou clicando com o botão direito na janela)
 - Execute-o pressionando `Enter`
@@ -29,11 +25,10 @@ wsl --install
 
 :x: Se você encontrar uma mensagem de erro (ou se vir algum texto em vermelho na janela), por favor **entre em contato com um professor**
 
-### Windows 10
+<details>
+<summary>Solução de problemas para Windows 10 (apenas se necessário, consulte um professor)</summary>
 
-#### Instale o WSL 1
-
-Se você estiver executando o Windows 10, primeiro instalaremos o WSL 1 por meio do Terminal PowerShell.
+#### Para Windows 10 < 2004: instale o WSL 1 primeiro
 
 :warning: Nas instruções a seguir, esteja ciente do pressionamento de tecla `Ctrl` + `Shift` + `Enter` para executar o **Windows PowerShell** com privilégios de administrador em vez de apenas clicar em `Ok` ou pressionar `Enter` .
 
@@ -64,7 +59,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: Se você encontrar uma mensagem de erro (ou se vir algum texto em vermelho na janela), por favor **entre em contato com um professor**
 
-#### Atualizar para WSL 2
+#### Para Windows 10 com WSL 1: Atualizar para WSL 2
 
 Se você estiver executando o Windows 10, atualizaremos o WSL para a versão 2.
 
@@ -82,7 +77,7 @@ Assim que o computador for reiniciado, precisamos baixar o instalador WSL2.
 
 :x: Se você encontrar o erro "Esta atualização se aplica apenas a máquinas com o subsistema Windows para Linux", **clique com o botão direito** no programa e selecione `uninstall`; você poderá instalá-lo normalmente desta vez.
 
-#### Torne o WSL 2 o subsistema Windows padrão para Linux
+#### Para Windows 10 com WSL 1: Torne o WSL 2 o subsistema Windows padrão para Linux
 
 Se você estiver executando o Windows 10, definiremos a versão padrão do WSL como 2.
 
@@ -113,4 +108,6 @@ wsl --set-default-version 2
    Siga as etapas descritas [aqui](https://winaero.com/enable-use-hyper-v-windows-10/) até ativar o grupo <strong>Hyper-V</strong>
 
    :information_source: Se você estiver executando o Windows 10 **Home edition**, o recurso Hyper-V não estará disponível para o seu sistema operacional. Não bloqueia e você ainda pode continuar seguindo as instruções abaixo :ok_hand:
+</details>
+
 </details>

--- a/_partials/windows_terminal.md
+++ b/_partials/windows_terminal.md
@@ -6,7 +6,10 @@
 
 If you are running Windows 11, the Windows Terminal is already installed and you can proceed to the next section :point_down:
 
-If you are running Windows 10, let's install Windows Terminal, a real modern terminal:
+If you are running Windows 10, let's install Windows Terminal, a real modern terminal.
+
+<details>
+<summary><strong>Windows 10</strong>: Install Windows Terminal</summary>
 
 - Click on `Start`
 - Type  `Microsoft Store`
@@ -31,6 +34,8 @@ If you are running Windows 10, let's install Windows Terminal, a real modern ter
 
 Once the installation is finished, the `Install` button becomes a `Launch` button: click on it.
 
+</details>
+
 ### Ubuntu as the default terminal
 
 Let's make Ubuntu the default terminal of your Windows Terminal application.
@@ -47,7 +52,7 @@ It should open the terminal settings:
 
 You may see an orange circle rather than a penguin as the logo for Ubuntu.
 
-We have circle in red the part you will change:
+We have circled in red the part you need to change:
 
 ![Windows Terminal JSON settings file](images/windows_terminal_settings_json.png)
 
@@ -61,7 +66,7 @@ First, let's ask Ubuntu to start directly inside your Ubuntu Home Directory inst
 
 :warning: Do not forget the comma at the end of the line!
 
-Then, let's disable warning for copy-pasting commands between Windows and Ubuntu:
+Then, let's disable warnings for copy-pasting commands between Windows and Ubuntu:
 - Locate the line `"defaultProfile": "{2c4de342-...}"`
 - Add the following line after it:
 

--- a/_partials/windows_ubuntu.md
+++ b/_partials/windows_ubuntu.md
@@ -2,13 +2,13 @@
 
 ### Installation
 
-:information_source: The following instructions depend on your version of Windows. Please execute only the instructions corresponding to your version :point_down:
+After restarting you computer, you should see a terminal window saying WSL is resuming the Ubuntu installation process. When it's done, Ubuntu will be launched.
 
-#### Windows 11
+<details>
+<summary>Troubleshooting for Windows 10 (only if needed, check with a TA)
+</summary>
 
-If you are running Windows 11, after restarting you computer, you should see a terminal window saying WSL is resuming the Ubuntu installation process. When it's done, Ubuntu will be launched.
-
-#### Windows 10
+If the Ubuntu installation did not resume, first try it again: launch Powershell or the Command Prompt again and run `wsl --install` again.
 
 If you are running Windows 10, let's install Ubuntu throught the Microsoft Store:
 
@@ -34,6 +34,8 @@ If you are running Windows 10, let's install Ubuntu throught the Microsoft Store
 
 Once the installation is finished, the `Get` button becomes a `Open` button: click on it.
 
+</details>
+
 ### First launch
 
 At first launch, you will be asked some information:
@@ -47,7 +49,6 @@ At first launch, you will be asked some information:
 
 :warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type your password and when you're done, press `Enter`.
 
-You can close the Ubuntu window now that it is installed on your computer.
 
 ### Check the WSL version of Ubuntu
 
@@ -77,7 +78,6 @@ wsl -l -v
   :heavy_check_mark: After a few seconds, you should get the following message: `The conversion is complete`.
 
   :x: If it does not work, we need to be sure that Ubuntu files are not compressed.
-</details>
 
 <details>
   <summary>Check for Uncompressed Files</summary>
@@ -95,6 +95,22 @@ wsl -l -v
 
   :x: If the conversion still does not work, please **contact a teacher**.
 </details>
+
+You can close this terminal now.
+
+</details>
+
+### Check your username
+
+Type this in the Ubuntu terminal:
+
+```bash
+whoami
+```
+
+It should return the username you chose before.
+
+:x: It if says `root`, **contact a TA** before continuing!
 
 ### Check the locale
 
@@ -125,5 +141,3 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-You can now close this terminal window.

--- a/_partials/windows_version.md
+++ b/_partials/windows_version.md
@@ -11,25 +11,16 @@ To check your Windows version:
 - Type  `winver`
 - Press `Enter`
 
-:heavy_check_mark: If the first words of this window are **Windows 10 or Windows 11** you're good to go :+1:
+:heavy_check_mark: If the first words of this window are **Windows 11** you're good to go :+1:
 
-:x: If not, you cannot proceed with this setup. You have to upgrade to Windows 10 first :point_down:
+If the first words of this window are **Windows 11**, check the **Version number**:
+
+:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+
+:x: If it is below `2004`, you need to run an update.
 
 <details>
-  <summary>Upgrade to Windows 10</summary>
-
-  - Download Windows 10 from [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-  - Install it. It should take roughly an hour, but this depends on your computer.
-  - When the installation is over, execute the commands above :point_up: to check that you now have **Windows 10**.
-</details>
-
-:information_source: [Windows 11 upgrade is rolling out now](https://www.microsoft.com/en-us/windows/get-windows-11), which means it may or may not be available for your computer just yet.
-
-:warning: **If you have Windows 10 installed, you don't need to upgrade to Windows 11 to proceed with this setup**.
-
-### Latest updates
-
-Once you're sure that you're using Windows 10 or 11, you need to install all the latest updates.
+<summary>Install updates</summary>
 
 Open Windows Update:
 - Press `Windows` + `R`
@@ -57,16 +48,14 @@ Open Windows Update:
   Then let's try updates again!
 </details>
 
-### Minimum version
-
-Some of the tools we need to install have been release with the `1903` version **or above** of Windows 10 so we need to make sure you have at least this one.
+Check the version number again:
 
 - Press `Windows` + `R`
 - Type  `winver`
 - Press `Enter`
 
-Check the **Version number**:
+:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
 
-:heavy_check_mark: If it says at least `1903`, you are good to go :+1:
+:x: If it is below `2004`, **contact a TA**.
 
-:x: If it is below `1903`, please **contact a teacher**.
+</details>

--- a/_partials/windows_version.md
+++ b/_partials/windows_version.md
@@ -13,49 +13,49 @@ To check your Windows version:
 
 :heavy_check_mark: If the first words of this window are **Windows 11** you're good to go :+1:
 
-If the first words of this window are **Windows 11**, check the **Version number**:
+If the first words of this window are **Windows 10**, check the **Version number**:
 
-:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+- :heavy_check_mark: If it says at least `2004`, you are good to go :+1:
 
-:x: If it is below `2004`, you need to run an update.
+- :x: If it is below `2004`, you need to run an update.
 
-<details>
-<summary>Install updates</summary>
+- <details>
+  <summary>How to install updates?</summary>
 
-Open Windows Update:
-- Press `Windows` + `R`
-- Type  `ms-settings:windowsupdate`
-- Press `Enter`
-- Click on `Check updates`
-
-:heavy_check_mark: If you see a green check mark and the message "You're up to date", you're good to go :+1:
-
-:warning: If you have a red exclamation mark and the message "Update available", please install them and repeat the process until it says that you are up to date :loop:
-
-:x: If you have an error message about Windows not being able to apply updates, please **contact a teacher**.
-
-<details>
-  <summary>Activate Windows Update Service to fix Updates</summary>
-
-  Some antiviruses and pieces of software deactivate the Update service we need, resulting in the error you see. Let's fix that!
+  Open Windows Update:
   - Press `Windows` + `R`
-  - Type  `services.msc`
+  - Type  `ms-settings:windowsupdate`
   - Press `Enter`
-  - Double Click `Windows Update Service`
-  - Set its `Startup` to `Automatic`
-  - Click on `Start`
-  - Click on `Ok`
-  Then let's try updates again!
-</details>
+  - Click on `Check updates`
 
-Check the version number again:
+  :heavy_check_mark: If you see a green check mark and the message "You're up to date", you're good to go :+1:
 
-- Press `Windows` + `R`
-- Type  `winver`
-- Press `Enter`
+  :warning: If you have a red exclamation mark and the message "Update available", please install them and repeat the process until it says that you are up to date :loop:
 
-:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+  :x: If you have an error message about Windows not being able to apply updates, please **contact a teacher**.
 
-:x: If it is below `2004`, **contact a TA**.
+  <details>
+    <summary>Activate Windows Update Service to fix Updates</summary>
 
-</details>
+    Some antiviruses and pieces of software deactivate the Update service we need, resulting in the error you see. Let's fix that!
+    - Press `Windows` + `R`
+    - Type  `services.msc`
+    - Press `Enter`
+    - Double Click `Windows Update Service`
+    - Set its `Startup` to `Automatic`
+    - Click on `Start`
+    - Click on `Ok`
+    Then let's try updates again!
+  </details>
+
+  Check the version number again:
+
+  - Press `Windows` + `R`
+  - Type  `winver`
+  - Press `Enter`
+
+  :heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+
+  :x: If it is below `2004`, **contact a TA**.
+
+  </details>

--- a/_partials/windows_wsl.md
+++ b/_partials/windows_wsl.md
@@ -2,21 +2,17 @@
 
 WSL is the development environment we are using to run Ubuntu. You can learn more about WSL [here](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: The following instructions depend on your version of Windows. Please execute only the instructions corresponding to your version :point_down:
+We will install WSL 2 and Ubuntu in one command through the Windows Command Prompt.
 
-### Windows 11
-
-If you are running Windows 11, we will install WSL 2 and Ubuntu in one command through the Windows Terminal.
-
-:warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows Terminal** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
+:warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows Command Prompt** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
 
 - Press `Windows` + `R`
-- Type  `wt`
+- Type  `cmd`
 - Press **`Ctrl` + `Shift` + `Enter`**
 
 :warning: You may have to accept the UAC confirmation about the privilege elevation.
 
-A blue terminal window will appear:
+A black terminal window will appear:
 - Copy the following command (`Ctrl` + `C`)
 - Paste it into the terminal window (`Ctrl` + `V` or by right-clicking in the window)
 - Run it by pressing `Enter`
@@ -27,13 +23,13 @@ wsl --install
 
 :heavy_check_mark: If the command ran without any error, please restart your computer and continue below :+1:
 
-:x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**
+:x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**.
 
-### Windows 10
+<details>
+<summary>Troubleshooting for Windows 10 (only if needed, check with a TA)
+</summary>
 
-#### Install WSL 1
-
-If you are running Windows 10, we will first install WSL 1 through the PowerShell Terminal.
+#### For Windows 10 < 2004: install WSL 1 first
 
 :warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows PowerShell** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
 
@@ -64,7 +60,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**
 
-#### Upgrade to WSL 2
+#### For Windows 10 users running WSL 1: Upgrade to WSL 2
 
 If you are running Windows 10, we will then upgrade WSL to version 2.
 
@@ -82,7 +78,7 @@ Once your computer has restarted, we need to download the WSL2 installer.
 
 :x: If you encounter the error "This update only applies to machines with the Windows Subsystem for Linux", **right click** on the program and select `uninstall`; you shall be able to install it normally this time.
 
-#### Make WSL 2 the default Windows Subsystem for Linux
+#### For Windows 10 users running WSL 1: Make WSL 2 the default Windows Subsystem for Linux
 
 If you are running Windows 10, we will set WSL default version to 2.
 
@@ -113,4 +109,6 @@ wsl --set-default-version 2
   Follow the steps described [here](https://winaero.com/enable-use-hyper-v-windows-10/) until you enable the group <strong>Hyper-V</strong>
 
   :information_source: If you are running Windows 10 **Home edition**, Hyper-V feature is not available for your operating system. It's non-blocking and you can still continue to follow the instructions below :ok_hand:
+</details>
+
 </details>

--- a/windows.es.md
+++ b/windows.es.md
@@ -62,25 +62,16 @@ Para chequear la versión de tu Windows:
 - Escribe  `winver`
 - Presiona `Enter`
 
-:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10 o Windows 11**, entonces todo está bien y puedes continuar trabajando en la configuración :+1:
+:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 11**, entonces todo está bien y puedes continuar trabajando en la configuración :+1:
 
-:x: Si no es el caso, no puedes continuar. Primero debes actualizar tu versión a Windows 10 :point_down:
+:heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10**, verifica el **número de la versión**:
+
+:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+
+:x: Si es inferior a `2004`, debes actualizar tu versión.
 
 <details>
-  <summary>Actualizar a Windows 10</summary>
-
-  - Descarga Windows 10 desde [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-  - Instálalo. Debería tomar como una hora pero realmente depende de tu computadora.
-  - Cuando termine la instalación, ejecuta los comandos de aquí arriba :point_up: para chequear que tengas **Windows 10**.
-</details>
-
-:information_source: [La actualización de Windows 11 está en curso en este momento](https://www.microsoft.com/en-us/windows/get-windows-11). Esto significa que puede que esté o que aún no esté disponible para tu computadora.
-
-:warning: **Si tienes Windows 10 instalado, no necesitas actualizarlo a Windows 11 para hacer esta configuración**.
-
-### Últimas actualizaciones
-
-Una vez que estés seguro de que estés usando Windows 10 o 11, instala las siguientes actualizaciones.
+  <summary>Últimas actualizaciones</summary>
 
 Abre Windows Update:
 - Presiona `Windows` + `R`
@@ -108,19 +99,17 @@ Abre Windows Update:
   ¡Ahora intenta instalar las actualizaciones nuevamente!
 </details>
 
-### Requisito mínimo para la versión
-
-Algunas de las herramientas que necesitamos han salido con la versión `1903` **o superior** de Windows 10, así que necesitamos asegurarnos de que al menos tengamos esa.
+Verifica el número de la versión:
 
 - Presiona `Windows` + `R`
 - Escribe  `winver`
 - Presiona `Enter`
 
-Verifica el **número de la versión**:
+:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
 
-:heavy_check_mark: Si dice al menos `1903`, entonces todo está bien :+1:
+:x: Si es inferior a `2004`, por favor **contacta a un profesor**.
 
-:x: Si es inferior a `1903`, por favor **contacta a un profesor**.
+</details>
 
 
 ## Virtualización
@@ -166,21 +155,17 @@ Normalmente ya es el caso en muchas computadoras. Verifiquemos:
 
 WSL es el ambiente de entorno que estamos usando para usar Ubuntu. Puedes aprender más sobre WSL [aquí](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: Las instrucciones que verás a continuación dependen de la versión de Windows que tengas. Por favor ejecuta solamente las instrucciones que correspondan a tu versión :point_down:
+Instalaremos WSL 2 y Ubuntu con un comando a través de la Windows Command Prompt.
 
-### Windows 11
-
-Si usas Windows 11, instalaremos WSL 2 y Ubuntu con un comando a través de la terminal de Windows.
-
-:warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar la **terminal de Windows** con privilegios de administrador en lugar de simplemente hacer clic en `Ok` o presionar `Enter`.
+:warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar la **Windows Command Prompt** con privilegios de administrador en lugar de simplemente hacer clic en `Ok` o presionar `Enter`.
 
 - Presiona `Windows` + `R`
-- Escribe `wt`
+- Escribe `cmd`
 - Presiona **`Ctrl` + `Shift` + `Enter`**
 
 :warning: tal vez tengas que aceptar la confirmación UAC sobre el cambio en los privilegios.
 
-Un ventana de terminal azul aparecerá:
+Un ventana de terminal aparecerá:
 - Copia el siguiente comando (`Ctrl` + `C`)
 - Pégalo en la ventana de la terminal (`Ctrl` + `V` o haciendo clic derecho en la ventana)
 - Ejecútalo presionado `Enter`
@@ -193,11 +178,10 @@ wsl --install
 
 :x: Si obtienes un mensaje de error (o si ves algún texto en rojo en la ventana), por favor **contacta a un profesor**
 
-### Windows 10
+<details>
+<summary>Solución de problemas para Windows 10 (solo si es necesario, consulta con un profesor)</summary>
 
-#### Instalación de WSL 1
-
-Si tienes Windows 10, primero instalaremos WSL 1 por medio de la Terminal de PowerShell.
+#### Para Windows 10 < 2004: instala primero WSL 1
 
 :warning: en esta instrucción, utiliza el atajo `Ctrl` + `Shift` + `Enter` para usar **Windows PowerShell** con privilegios de administrador en lugar de hacer clic en `Ok` o presionar `Enter`.
 
@@ -228,7 +212,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: Si obtienes un mensaje de error (o si ves algún texto en rojo en la ventada), por favor **contacta a un profesor**
 
-#### Actualización a WSL 2
+#### Para Windows 10 con WSL 1: Actualización a WSL 2
 
 Si tienes Windows 10, actualizaremos WSL a la versión 2.
 
@@ -246,7 +230,7 @@ Cuando se reinicie tu computadora, descarga el instalador de WSL2.
 
 :x: Si obtienes el siguiente error "This update only applies to machines with the Windows Subsystem for Linux", **haz clic derecho** en el programa y selecciona `uninstall`; esta vez deberías poder instalarlo sin problemas.
 
-#### Coloca WSL 2 como el Subsistema Windows por defecto para Linux
+#### Para Windows 10 con WSL 1: Coloca WSL 2 como el Subsistema Windows por defecto para Linux
 
 Si tienes Windows 10, pondremos la versión predeterminada de WSL en 2.
 
@@ -279,18 +263,20 @@ wsl --set-default-version 2
   :information_source: Si tienes Windows 10 **Home edition**, la feature Hyper-V no está disponible para su sistema operativo. No es un bloqueo y puedes continuar con las siguientes instrucciones aquí abajo :ok_hand:
 </details>
 
+</details>
+
 
 ## Ubuntu
 
 ### Instalación
 
-:information_source: Las instrucciones que verás a continuación dependen de la versión de Windows que tengas. Por favor solo sigue las instrucciones que correspondan a tu versión de Windows :point_down:
+Después de reiniciar tu computadora, deberías ver una ventana de terminal diciendo WSL está retomando el proceso de instalación de Ubuntu. Cuando termine, iniciará Ubuntu.
 
-#### Windows 11
+<details>
+<summary>Solución de problemas para Windows 10 (solo si es necesario, consulta con un profesor)</summary>
 
-Si estás utilizando Windows 11, después de reiniciar tu computadora, deberías ver una ventana de terminal diciendo WSL está retomando el proceso de instalación de Ubuntu. Cuando termine, iniciará Ubuntu.
-
-#### Windows 10
+Si la instalación de Ubuntu no se reanudó, primero intenta nuevamente: abre Powershell o el Símbolo del sistema y ejecuta `wsl --install` otra vez.
+</details>
 
 Si tienes Windows 10, instala la terminal de Windows por medio de la Microsoft Store:
 
@@ -316,6 +302,8 @@ Si tienes Windows 10, instala la terminal de Windows por medio de la Microsoft S
 
 Cuando termine la instalación, el botón `Get` se transformará en un botón `Open`: Haz clic en él.
 
+</details>
+
 ### Primer uso
 
 La primera vez que lo abras, te pedirán que:
@@ -328,8 +316,6 @@ La primera vez que lo abras, te pedirán que:
 - Confírmalo
 
 :warning: Cuando escribas tu contraseña no verás nada en la pantalla. **Esto es normal**. Es una herramienta de seguridad para ocultar tanto el contenido de tu contraseña como su longitud. Simplemente escribe tu contraseña y presiona `Enter` al terminar.
-
-Ahora puedes cerrar la ventana de Ubuntu ya que está instalado en tu computadora.
 
 ### Chequea la versión WSL de Ubuntu
 
@@ -359,7 +345,6 @@ wsl -l -v
   :heavy_check_mark: Deberías obtener el siguiente mensaje en algunos segundos: `The conversion is complete`. Esto significa que la conversión ha sido completada.
 
   :x: Si no funciona, tendremos que asegurarnos de que los archivos de Ubuntu no estén comprimidos.
-</details>
 
 <details>
   <summary>Chequea si los archivos no están comprimidos</summary>
@@ -378,7 +363,23 @@ wsl -l -v
   :x: Si la conversión aún no funciona, por favor **contacta a un profesor**.
 </details>
 
-### Compruebe la locale
+Ya puedes cerrar la ventana de la terminal.
+
+</details>
+
+### Comprueba tu nombre de usuario
+
+Escribe esto en la terminal de Ubuntu:
+
+```bash
+whoami
+```
+
+Debería devolver el nombre de usuario que elegiste anteriormente.
+
+:x: Si dice `root`, **contacta a un profesor** antes de continuar.
+
+### Comprueba la configuración regional (locale)
 
 La "locale" es un mecanismo que permite adaptar los programas a su idioma y país.
 
@@ -407,8 +408,6 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-Ya puedes cerrar la ventana de la terminal.
 
 
 ## Visual Studio Code
@@ -459,8 +458,10 @@ code .
 
 Si estás utilizando Windows 11, la terminal de Windows ya está instalada y puedes ir a la siguiente sección :point_down:
 
+Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal moderna.
 
-Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal moderna:
+<details>
+<summary>**Windows 10**: Instalar Windows Terminal</summary>
 
 - Haz clic en `Start`
 - Escribe `Microsoft Store`
@@ -484,6 +485,8 @@ Si tienes Windows 10, instala la terminal de Windows. Verás que es una terminal
 </details>
 
 Cuando termine la instalación, el botón `Install` se transformará en un botón `Launch`: haz clic en él.
+
+</details>
 
 ### Ubuntu como terminal predeterminada
 

--- a/windows.es.md
+++ b/windows.es.md
@@ -66,50 +66,50 @@ Para chequear la versión de tu Windows:
 
 :heavy_check_mark: Si las primeras palabras de esta ventana son **Windows 10**, verifica el **número de la versión**:
 
-:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+- :heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
 
-:x: Si es inferior a `2004`, debes actualizar tu versión.
+- :x: Si es inferior a `2004`, debes actualizar tu versión.
 
-<details>
-  <summary>Últimas actualizaciones</summary>
+- <details>
+  <summary>Cómo instalar las últimas actualizaciones?</summary>
 
-Abre Windows Update:
-- Presiona `Windows` + `R`
-- Escribe `ms-settings:windowsupdate`
-- Presiona `Enter`
-- Haz clic en `Check updates`
-
-:heavy_check_mark: Si tienes una marca verde y el siguiente mensaje "You're up to date", entonces todo está bien :+1:
-
-:warning: Si obtienes una exclamación roja y el siguiente mensaje "Update available", por favor instala las actualizaciones y repite el proceso hasta que diga que todo está actualizado :loop:
-
-:x: Si obtienes un mensaje de error diciendo que Windows no puede aplicar las actualizaciones, por favor **contacta a un profesor**.
-
-<details>
-  <summary>Activa Windows Update Service para resolver las Actualizaciones</summary>
-
-  Algunos antivirus y programas deshabilitan las actualizaciones que necesitamos y luego se muestra un error. ¡Solucionemos esto!
+  Abre Windows Update:
   - Presiona `Windows` + `R`
-  - Escribe `services.msc`
+  - Escribe `ms-settings:windowsupdate`
   - Presiona `Enter`
-  - Haz doble clic en `Windows Update Service`
-  - Coloca su `Startup` en `Automatic`
-  - Haz clic en `Start`
-  - Haz clic en `Ok`
-  ¡Ahora intenta instalar las actualizaciones nuevamente!
-</details>
+  - Haz clic en `Check updates`
 
-Verifica el número de la versión:
+  :heavy_check_mark: Si tienes una marca verde y el siguiente mensaje "You're up to date", entonces todo está bien :+1:
 
-- Presiona `Windows` + `R`
-- Escribe  `winver`
-- Presiona `Enter`
+  :warning: Si obtienes una exclamación roja y el siguiente mensaje "Update available", por favor instala las actualizaciones y repite el proceso hasta que diga que todo está actualizado :loop:
 
-:heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+  :x: Si obtienes un mensaje de error diciendo que Windows no puede aplicar las actualizaciones, por favor **contacta a un profesor**.
 
-:x: Si es inferior a `2004`, por favor **contacta a un profesor**.
+  <details>
+    <summary>Activa Windows Update Service para resolver las Actualizaciones</summary>
 
-</details>
+    Algunos antivirus y programas deshabilitan las actualizaciones que necesitamos y luego se muestra un error. ¡Solucionemos esto!
+    - Presiona `Windows` + `R`
+    - Escribe `services.msc`
+    - Presiona `Enter`
+    - Haz doble clic en `Windows Update Service`
+    - Coloca su `Startup` en `Automatic`
+    - Haz clic en `Start`
+    - Haz clic en `Ok`
+    ¡Ahora intenta instalar las actualizaciones nuevamente!
+  </details>
+
+  Verifica el número de la versión:
+
+  - Presiona `Windows` + `R`
+  - Escribe  `winver`
+  - Presiona `Enter`
+
+  :heavy_check_mark: Si dice al menos `2004`, entonces todo está bien :+1:
+
+  :x: Si es inferior a `2004`, por favor **contacta a un profesor**.
+
+  </details>
 
 
 ## Virtualización

--- a/windows.fr.md
+++ b/windows.fr.md
@@ -64,53 +64,53 @@ Pour connaître ta version de Windows :
 
 :heavy_check_mark: Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 11**, c’est bon :+1:
 
-Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10**, vérifie numéro de version:
+Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10**, vérifie le numéro de version:
 
-:heavy_check_mark: Si la version indique au moins `2004`, c’est bon :+1:
+- :heavy_check_mark: Si la version indique au moins `2004`, c’est bon :+1:
 
-:x: Sinon, il faut que tu mettes à jour ton Windows.
+- :x: Sinon, il faut que tu mettes à jour ton Windows.
 
-<details>
-  <summary> Dernières mises à jour</summary>
+- <details>
+  <summary>Comment installer les dernières mises à jour</summary>
 
-Ouvre Windows Update :
-- Appuie sur `Windows` + `R`
-- Saisis `ms-settings:windowsupdate`
-- Appuie sur `Enter`
-- Clique sur « Rechercher les mises à jour »
-
-:heavy_check_mark: Si tu vois apparaître une coche verte et le message « Vous êtes à jour », c’est bon :+1:
-
-:warning: Si tu vois apparaître un point d’exclamation rouge et le message « Mise à jour disponible », installe-la et recommence jusqu’à ce que le message « Vous êtes à jour » apparaisse :loop:
-
-:x: Si tu vois apparaître un message d’erreur indiquant que Windows ne peut pas appliquer les mises à jour, **demande au prof**.
-
-<details>
-  <summary>Activer le service Windows Update pour corriger les mises à jour</summary>
-
-  Certains antivirus et logiciels désactivent le service de mise à jour dont on a besoin, entraînant l’erreur que tu vois apparaître. On va corriger ça !
+  Ouvre Windows Update :
   - Appuie sur `Windows` + `R`
-  - Saisis `services.msc`
+  - Saisis `ms-settings:windowsupdate`
   - Appuie sur `Enter`
-  - Double-clique sur `Windows Update Service`
-  - Définis `Startup` sur `Automatic`
-  - Clique sur `Start`
-  - Clique sur `Ok`
-  On va maintenant réessayer d’effectuer les mises à jour.
-</details>
+  - Clique sur « Rechercher les mises à jour »
 
-Vérifie le numéro de version :
+  :heavy_check_mark: Si tu vois apparaître une coche verte et le message « Vous êtes à jour », c’est bon :+1:
 
-- Appuie sur `Windows` + `R`
-- Saisis `winver`
-- Appuie sur `Enter`
+  :warning: Si tu vois apparaître un point d’exclamation rouge et le message « Mise à jour disponible », installe-la et recommence jusqu’à ce que le message « Vous êtes à jour » apparaisse :loop:
+
+  :x: Si tu vois apparaître un message d’erreur indiquant que Windows ne peut pas appliquer les mises à jour, **demande au prof**.
+
+  <details>
+    <summary>Activer le service Windows Update pour corriger les mises à jour</summary>
+
+    Certains antivirus et logiciels désactivent le service de mise à jour dont on a besoin, entraînant l’erreur que tu vois apparaître. On va corriger ça !
+    - Appuie sur `Windows` + `R`
+    - Saisis `services.msc`
+    - Appuie sur `Enter`
+    - Double-clique sur `Windows Update Service`
+    - Définis `Startup` sur `Automatic`
+    - Clique sur `Start`
+    - Clique sur `Ok`
+    On va maintenant réessayer d’effectuer les mises à jour.
+  </details>
+
+  Vérifie le numéro de version :
+
+  - Appuie sur `Windows` + `R`
+  - Saisis `winver`
+  - Appuie sur `Enter`
 
 
-:heavy_check_mark: Si la version indique au moins `1903`, c’est bon :+1:
+  :heavy_check_mark: Si la version indique au moins `1903`, c’est bon :+1:
 
-:x: S’il s’agit d’une version antérieure, **demande au prof**.
+  :x: S’il s’agit d’une version antérieure, **demande au prof**.
 
-</details>
+  </details>
 
 
 ## Virtualisation

--- a/windows.fr.md
+++ b/windows.fr.md
@@ -62,25 +62,16 @@ Pour connaître ta version de Windows :
 - Saisis `winver`
 - Appuie sur `Enter`
 
-:heavy_check_mark: Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10 ou Windows 11**, c’est bon :+1:
+:heavy_check_mark: Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 11**, c’est bon :+1:
 
-:x: Sinon, tu ne pourras pas utiliser cette configuration. Il faut que tu mettes à jour ton Windows à la version 10 :point_down:
+Si les premiers mots qui apparaissent dans cette fenêtre sont **Windows 10**, vérifie numéro de version:
+
+:heavy_check_mark: Si la version indique au moins `2004`, c’est bon :+1:
+
+:x: Sinon, il faut que tu mettes à jour ton Windows.
 
 <details>
-  <summary>Mise à niveau vers Windows 10</summary>
-
-  - Télécharge Windows 10 depuis [Microsoft](https://www.microsoft.com/fr-fr/software-download/windows10)
-  - Installe-le. L’installation devrait prendre une heure environ, mais cela dépend de ton ordinateur
-  - Une fois l’installation terminée, exécute les commandes ci-dessus pour vérifier que tu es sous **Windows 10**
-</details>
-
-:information_source: [La mise à jour Windows 11 est toujours en cours de déploiement](https://www.microsoft.com/en-us/windows/get-windows-11), ce qui signifie qu'elle peut être disponible, ou pas, pour ton ordinateur.
-
-:warning: **Si tu as Windows 10 installé, tu n'as pas besoin de faire la mise à jour Windows 11 pour continuer cette configuration**.
-
-### Dernières mises à jour
-
-Une fois que tu as vérifié que tu utilises Windows 10 ou 11, tu vas devoir installer les dernières mises à jour.
+  <summary> Dernières mises à jour</summary>
 
 Ouvre Windows Update :
 - Appuie sur `Windows` + `R`
@@ -108,19 +99,18 @@ Ouvre Windows Update :
   On va maintenant réessayer d’effectuer les mises à jour.
 </details>
 
-### Version minimum
-
-Certains des outils qu’on doit installer sont compatibles avec la version `1903` **ou une version ultérieure** de Windows 10 ; on doit donc vérifier que tu as bien cette version au minimum.
+Vérifie le numéro de version :
 
 - Appuie sur `Windows` + `R`
 - Saisis `winver`
 - Appuie sur `Enter`
 
-Vérifie le **numéro de version** :
 
 :heavy_check_mark: Si la version indique au moins `1903`, c’est bon :+1:
 
 :x: S’il s’agit d’une version antérieure, **demande au prof**.
+
+</details>
 
 
 ## Virtualisation
@@ -167,21 +157,17 @@ C’est déjà le cas sur de nombreux ordinateurs. Vérifions-le :
 
 WSL est l’environnement de développement que l’on utilise pour exécuter Ubuntu. Pour en savoir plus sur WSL, [consulte cette page](https://docs.microsoft.com/fr-fr/windows/wsl/faq).
 
-:information_source: Les instructions suivantes dépendent de ta version de Windows. Exécute uniquement les instructions qui correspondent à ta version :point_down:
+Nous allons installer WSL 2 et Ubuntu en une seule commande via le Windows Command Prompt.
 
-### Windows 11
-
-Si tu as Windows 11, nous allons installer WSL 2 et Ubuntu en une seule commande via le Windows Terminal.
-
-:warning: Dans les instructions suivantes, utilise la combinaison de touches `Ctrl` + `Shift` + `Enter` pour exécuter **Windows Terminal** en tant qu’administrateur au lieu de cliquer simplement sur `Ok` ou d’appuyer sur `Enter`.
+:warning: Dans les instructions suivantes, utilise la combinaison de touches `Ctrl` + `Shift` + `Enter` pour exécuter **Windows Command Prompt** en tant qu’administrateur au lieu de cliquer simplement sur `Ok` ou d’appuyer sur `Enter`.
 
 - Appuie sur `Windows` + `R`
-- Saisis `wt`
+- Saisis `cmd`
 - Appuie sur **`Ctrl` + `Shift` + `Enter`**
 
 :warning: Tu devras peut-être accepter la confirmation UAC concernant l’octroi des droits d’administrateur.
 
-Une fenêtre de terminal bleue apparaîtra :
+Une fenêtre de terminal apparaîtra :
 - Copie la commande suivante (`Ctrl` + `C`)
 - Colle-la dans la fenêtre du terminal (`Ctrl` + `V` ou en faisant un clic droit dans la fenêtre)
 - Exécute-les en appuyant sur `Enter`
@@ -192,13 +178,12 @@ wsl --install
 
 :heavy_check_mark: Si la commande s’exécute sans erreur, redémarre ton ordinateur et suis les instructions ci-dessous :+1:
 
-:x: Si tu obtiens un message d’erreur (ou si tu vois apparaître du texte en rouge dans la fenêtre), **demande au prof**
+:x: Si tu obtiens un message d’erreur (ou si tu vois apparaître du texte en rouge dans la fenêtre), **demande au prof**.
 
-### Windows 10
+<details>
+<summary>Dépannage pour Windows 10 (uniquement si nécessaire, vérifie avec un professeur)</summary>
 
-#### Installer WSL 1
-
-Si tu as Windows 10, on va d'abord installer WSL 1 à partir du terminal PowerShell.
+#### Pour Windows 10 < 2004 : installer d'abord WSL 1
 
 :warning: Dans les instructions suivantes, utilise la combinaison de touches `Ctrl` + `Shift` + `Enter` pour exécuter **Windows PowerShell** en tant qu’administrateur au lieu de cliquer simplement sur `Ok` ou d’appuyer sur `Enter`.
 
@@ -229,7 +214,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: Si tu obtiens un message d’erreur (ou si tu vois apparaître du texte en rouge dans la fenêtre), **demande au prof**
 
-#### Mise à niveau vers WSL 2
+#### Pour Windows 10 avec WSL 1 : Mise à niveau vers WSL 2
 
 Si tu as Windows 10, on va maintenant mettre à jour WSL à la version 2.
 
@@ -247,7 +232,7 @@ Une fois que ton ordinateur a redémarré, on doit télécharger le programme d�
 
 :x: Si tu obtiens l’erreur « Cette mise à jour s’applique seulement aux machines avec le sous-système Windows pour Linux », **fais un clic droit** sur le programme et sélectionne `uninstall` ; tu devrais pouvoir l’installer normalement cette fois-ci.
 
-#### Définir WSL 2 comme sous-système Windows pour Linux par défaut
+#### Pour Windows 10 avec WSL 1 : Définir WSL 2 comme sous-système Windows pour Linux par défaut
 
 Si tu as Windows 10, on va enfin définir la version 2 de WSL comme étant la version par défaut.
 
@@ -280,18 +265,19 @@ wsl --set-default-version 2
   :information_source: Si tu as Windows 10 **Home edition**, la fonction Hyper-V n'est pas disponible sur ton système d'exploitation. Ce n'est pas bloquant et tu peux continuer à suivre les instructions ci-dessous :ok_hand:
 </details>
 
+</details>
+
 
 ## Ubuntu
 
 ### Installation
 
-:information_source: Les instructions suivantes dépendent de ta version de Windows. N'exécute que les instructions qui correspondent à ta version :point_down:
-
-#### Windows 11
-
 Si tu as Windows 11, après avoir redémarré ton ordinateur, tu devrais voir une fenêtre de terminal indiquant que WSL poursuit le processus d'installation d'Ubuntu. Lorsque c'est terminé, Ubuntu va se lancer.
 
-#### Windows 10
+<details>
+<summary>Résolution des problèmes pour Windows 10 (uniquement si nécessaire, vérifie avec un TA)</summary>
+
+Si l'installation d'Ubuntu ne reprend pas, essaye d'abord à nouveau : relance Powershell ou l'Invite de commandes et exécute la commande `wsl --install` une nouvelle fois.
 
 Si tu as Windows 10, installons Ubuntu via le Microsoft Store :
 
@@ -316,6 +302,8 @@ Si tu as Windows 10, installons Ubuntu via le Microsoft Store :
 </details>
 
 Une fois l’installation terminée, le bouton « Installer » se transforme en bouton « Lancer » ; clique dessus.
+
+</details>
 
 ### Premier lancement
 
@@ -360,7 +348,6 @@ wsl -l -v
   :heavy_check_mark: Au bout de quelques secondes, tu devrais voir apparaître le message suivant : `The conversion is complete`.
 
   :x: Si ce n’est pas le cas, il faut vérifier que les fichiers Ubuntu ne sont pas compressés.
-</details>
 
 <details>
   <summary>Vérifier que les fichiers sont décompressés</summary>
@@ -379,11 +366,28 @@ wsl -l -v
   :x: Si la conversion ne fonctionne pas, **demande au prof**.
 </details>
 
+Tu peux maintenant fermer cette fenêtre de terminal.
+
+</details>
+
+### Vérifier ton nom d'utilisateur
+
+Tape cette commande dans le terminal Ubuntu :
+
+```bash
+whoami
+```
+
+Cela devrait renvoyer le nom d'utilisateur que tu as choisi précédemment.
+
+:x: Si cela affiche `root`, **contacte un TA** avant de continuer !
+
+
 ### Vérifier la locale
 
 Le concept e "locale" permert de personnaliser les programms en fonction de ta langue et ton pays.
 
-Vérifions que la locale est bien en **anglais** ans le terminal :
+Vérifions que la locale est bien en **anglais** dans le terminal :
 
 ```bash
 locale
@@ -408,8 +412,6 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-Tu peux maintenant fermer cette fenêtre de terminal.
 
 
 ## Visual Studio Code
@@ -458,7 +460,10 @@ code .
 
 Si tu as Windows 11, le Windows Terminal est déjà installé et tu peux passer à la section suivante :point_down:
 
-Si tu as Windows 10, nous allons installer le Windows Terminal, un terminal vraiment moderne :
+Si tu as Windows 10, nous allons installer le Windows Terminal, un terminal vraiment moderne.
+
+<details>
+<summary><strong>Windows 10</strong>: Installer le Windows Terminal</summary>
 
 - Clique sur `Démarrer`
 - Saisis `Microsoft Store`
@@ -482,6 +487,8 @@ Si tu as Windows 10, nous allons installer le Windows Terminal, un terminal vrai
 </details>
 
 Une fois l’installation terminée, le bouton « Installer » se transforme en bouton « Lancer » ; clique dessus.
+
+</details>
 
 ### Définir Ubuntu comme terminal par défaut
 

--- a/windows.md
+++ b/windows.md
@@ -68,52 +68,52 @@ To check your Windows version:
 
 :heavy_check_mark: If the first words of this window are **Windows 11** you're good to go :+1:
 
-If the first words of this window are **Windows 11**, check the **Version number**:
+If the first words of this window are **Windows 10**, check the **Version number**:
 
-:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+- :heavy_check_mark: If it says at least `2004`, you are good to go :+1:
 
-:x: If it is below `2004`, you need to run an update.
+- :x: If it is below `2004`, you need to run an update.
 
-<details>
-<summary>Install updates</summary>
+- <details>
+  <summary>How to install updates?</summary>
 
-Open Windows Update:
-- Press `Windows` + `R`
-- Type  `ms-settings:windowsupdate`
-- Press `Enter`
-- Click on `Check updates`
-
-:heavy_check_mark: If you see a green check mark and the message "You're up to date", you're good to go :+1:
-
-:warning: If you have a red exclamation mark and the message "Update available", please install them and repeat the process until it says that you are up to date :loop:
-
-:x: If you have an error message about Windows not being able to apply updates, please **contact a teacher**.
-
-<details>
-  <summary>Activate Windows Update Service to fix Updates</summary>
-
-  Some antiviruses and pieces of software deactivate the Update service we need, resulting in the error you see. Let's fix that!
+  Open Windows Update:
   - Press `Windows` + `R`
-  - Type  `services.msc`
+  - Type  `ms-settings:windowsupdate`
   - Press `Enter`
-  - Double Click `Windows Update Service`
-  - Set its `Startup` to `Automatic`
-  - Click on `Start`
-  - Click on `Ok`
-  Then let's try updates again!
-</details>
+  - Click on `Check updates`
 
-Check the version number again:
+  :heavy_check_mark: If you see a green check mark and the message "You're up to date", you're good to go :+1:
 
-- Press `Windows` + `R`
-- Type  `winver`
-- Press `Enter`
+  :warning: If you have a red exclamation mark and the message "Update available", please install them and repeat the process until it says that you are up to date :loop:
 
-:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+  :x: If you have an error message about Windows not being able to apply updates, please **contact a teacher**.
 
-:x: If it is below `2004`, **contact a TA**.
+  <details>
+    <summary>Activate Windows Update Service to fix Updates</summary>
 
-</details>
+    Some antiviruses and pieces of software deactivate the Update service we need, resulting in the error you see. Let's fix that!
+    - Press `Windows` + `R`
+    - Type  `services.msc`
+    - Press `Enter`
+    - Double Click `Windows Update Service`
+    - Set its `Startup` to `Automatic`
+    - Click on `Start`
+    - Click on `Ok`
+    Then let's try updates again!
+  </details>
+
+  Check the version number again:
+
+  - Press `Windows` + `R`
+  - Type  `winver`
+  - Press `Enter`
+
+  :heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+
+  :x: If it is below `2004`, **contact a TA**.
+
+  </details>
 
 
 ## Virtualization

--- a/windows.md
+++ b/windows.md
@@ -66,25 +66,16 @@ To check your Windows version:
 - Type  `winver`
 - Press `Enter`
 
-:heavy_check_mark: If the first words of this window are **Windows 10 or Windows 11** you're good to go :+1:
+:heavy_check_mark: If the first words of this window are **Windows 11** you're good to go :+1:
 
-:x: If not, you cannot proceed with this setup. You have to upgrade to Windows 10 first :point_down:
+If the first words of this window are **Windows 11**, check the **Version number**:
+
+:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
+
+:x: If it is below `2004`, you need to run an update.
 
 <details>
-  <summary>Upgrade to Windows 10</summary>
-
-  - Download Windows 10 from [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-  - Install it. It should take roughly an hour, but this depends on your computer.
-  - When the installation is over, execute the commands above :point_up: to check that you now have **Windows 10**.
-</details>
-
-:information_source: [Windows 11 upgrade is rolling out now](https://www.microsoft.com/en-us/windows/get-windows-11), which means it may or may not be available for your computer just yet.
-
-:warning: **If you have Windows 10 installed, you don't need to upgrade to Windows 11 to proceed with this setup**.
-
-### Latest updates
-
-Once you're sure that you're using Windows 10 or 11, you need to install all the latest updates.
+<summary>Install updates</summary>
 
 Open Windows Update:
 - Press `Windows` + `R`
@@ -112,19 +103,17 @@ Open Windows Update:
   Then let's try updates again!
 </details>
 
-### Minimum version
-
-Some of the tools we need to install have been release with the `1903` version **or above** of Windows 10 so we need to make sure you have at least this one.
+Check the version number again:
 
 - Press `Windows` + `R`
 - Type  `winver`
 - Press `Enter`
 
-Check the **Version number**:
+:heavy_check_mark: If it says at least `2004`, you are good to go :+1:
 
-:heavy_check_mark: If it says at least `1903`, you are good to go :+1:
+:x: If it is below `2004`, **contact a TA**.
 
-:x: If it is below `1903`, please **contact a teacher**.
+</details>
 
 
 ## Virtualization
@@ -170,21 +159,17 @@ For many computers, this is already the case. Let's check:
 
 WSL is the development environment we are using to run Ubuntu. You can learn more about WSL [here](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: The following instructions depend on your version of Windows. Please execute only the instructions corresponding to your version :point_down:
+We will install WSL 2 and Ubuntu in one command through the Windows Command Prompt.
 
-### Windows 11
-
-If you are running Windows 11, we will install WSL 2 and Ubuntu in one command through the Windows Terminal.
-
-:warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows Terminal** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
+:warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows Command Prompt** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
 
 - Press `Windows` + `R`
-- Type  `wt`
+- Type  `cmd`
 - Press **`Ctrl` + `Shift` + `Enter`**
 
 :warning: You may have to accept the UAC confirmation about the privilege elevation.
 
-A blue terminal window will appear:
+A black terminal window will appear:
 - Copy the following command (`Ctrl` + `C`)
 - Paste it into the terminal window (`Ctrl` + `V` or by right-clicking in the window)
 - Run it by pressing `Enter`
@@ -195,13 +180,13 @@ wsl --install
 
 :heavy_check_mark: If the command ran without any error, please restart your computer and continue below :+1:
 
-:x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**
+:x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**.
 
-### Windows 10
+<details>
+<summary>Troubleshooting for Windows 10 (only if needed, check with a TA)
+</summary>
 
-#### Install WSL 1
-
-If you are running Windows 10, we will first install WSL 1 through the PowerShell Terminal.
+#### For Windows 10 < 2004: install WSL 1 first
 
 :warning: In the following instruction, please be aware of the `Ctrl` + `Shift` + `Enter` key stroke to execute **Windows PowerShell** with administrator privileges instead of just clicking on `Ok`or pressing `Enter`.
 
@@ -232,7 +217,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: If you encounter an error message (or if you see some text in red in the window), please **contact a teacher**
 
-#### Upgrade to WSL 2
+#### For Windows 10 users running WSL 1: Upgrade to WSL 2
 
 If you are running Windows 10, we will then upgrade WSL to version 2.
 
@@ -250,7 +235,7 @@ Once your computer has restarted, we need to download the WSL2 installer.
 
 :x: If you encounter the error "This update only applies to machines with the Windows Subsystem for Linux", **right click** on the program and select `uninstall`; you shall be able to install it normally this time.
 
-#### Make WSL 2 the default Windows Subsystem for Linux
+#### For Windows 10 users running WSL 1: Make WSL 2 the default Windows Subsystem for Linux
 
 If you are running Windows 10, we will set WSL default version to 2.
 
@@ -283,18 +268,20 @@ wsl --set-default-version 2
   :information_source: If you are running Windows 10 **Home edition**, Hyper-V feature is not available for your operating system. It's non-blocking and you can still continue to follow the instructions below :ok_hand:
 </details>
 
+</details>
+
 
 ## Ubuntu
 
 ### Installation
 
-:information_source: The following instructions depend on your version of Windows. Please execute only the instructions corresponding to your version :point_down:
+After restarting you computer, you should see a terminal window saying WSL is resuming the Ubuntu installation process. When it's done, Ubuntu will be launched.
 
-#### Windows 11
+<details>
+<summary>Troubleshooting for Windows 10 (only if needed, check with a TA)
+</summary>
 
-If you are running Windows 11, after restarting you computer, you should see a terminal window saying WSL is resuming the Ubuntu installation process. When it's done, Ubuntu will be launched.
-
-#### Windows 10
+If the Ubuntu installation did not resume, first try it again: launch Powershell or the Command Prompt again and run `wsl --install` again.
 
 If you are running Windows 10, let's install Ubuntu throught the Microsoft Store:
 
@@ -320,6 +307,8 @@ If you are running Windows 10, let's install Ubuntu throught the Microsoft Store
 
 Once the installation is finished, the `Get` button becomes a `Open` button: click on it.
 
+</details>
+
 ### First launch
 
 At first launch, you will be asked some information:
@@ -333,7 +322,6 @@ At first launch, you will be asked some information:
 
 :warning: When you type your password, nothing will show up on the screen, **that's normal**. This is a security feature to mask not only your password as a whole but also its length. Just type your password and when you're done, press `Enter`.
 
-You can close the Ubuntu window now that it is installed on your computer.
 
 ### Check the WSL version of Ubuntu
 
@@ -363,7 +351,6 @@ wsl -l -v
   :heavy_check_mark: After a few seconds, you should get the following message: `The conversion is complete`.
 
   :x: If it does not work, we need to be sure that Ubuntu files are not compressed.
-</details>
 
 <details>
   <summary>Check for Uncompressed Files</summary>
@@ -381,6 +368,22 @@ wsl -l -v
 
   :x: If the conversion still does not work, please **contact a teacher**.
 </details>
+
+You can close this terminal now.
+
+</details>
+
+### Check your username
+
+Type this in the Ubuntu terminal:
+
+```bash
+whoami
+```
+
+It should return the username you chose before.
+
+:x: It if says `root`, **contact a TA** before continuing!
 
 ### Check the locale
 
@@ -411,8 +414,6 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-You can now close this terminal window.
 
 
 ## Visual Studio Code
@@ -463,7 +464,10 @@ code .
 
 If you are running Windows 11, the Windows Terminal is already installed and you can proceed to the next section :point_down:
 
-If you are running Windows 10, let's install Windows Terminal, a real modern terminal:
+If you are running Windows 10, let's install Windows Terminal, a real modern terminal.
+
+<details>
+<summary><strong>Windows 10</strong>: Install Windows Terminal</summary>
 
 - Click on `Start`
 - Type  `Microsoft Store`
@@ -488,6 +492,8 @@ If you are running Windows 10, let's install Windows Terminal, a real modern ter
 
 Once the installation is finished, the `Install` button becomes a `Launch` button: click on it.
 
+</details>
+
 ### Ubuntu as the default terminal
 
 Let's make Ubuntu the default terminal of your Windows Terminal application.
@@ -504,7 +510,7 @@ It should open the terminal settings:
 
 You may see an orange circle rather than a penguin as the logo for Ubuntu.
 
-We have circle in red the part you will change:
+We have circled in red the part you need to change:
 
 ![Windows Terminal JSON settings file](images/windows_terminal_settings_json.png)
 
@@ -518,7 +524,7 @@ First, let's ask Ubuntu to start directly inside your Ubuntu Home Directory inst
 
 :warning: Do not forget the comma at the end of the line!
 
-Then, let's disable warning for copy-pasting commands between Windows and Ubuntu:
+Then, let's disable warnings for copy-pasting commands between Windows and Ubuntu:
 - Locate the line `"defaultProfile": "{2c4de342-...}"`
 - Add the following line after it:
 

--- a/windows.pt.md
+++ b/windows.pt.md
@@ -68,52 +68,52 @@ Para verificar sua versão do Windows:
 
 :heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 11** você está pronto para prosseguir :+1:
 
-:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10**, verifique o **Número da versão**::
+- :heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10**, verifique o **Número da versão**::
 
-:x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar.
+- :x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar.
 
-<details>
-   <summary>Ultimas atualizações</summary>
+- <details>
+  <summary>Como instalar as últimas atualizações?</summary>
 
-Abra a atualização do Windows:
-- Pressione `Windows` + `R`
-- Digite `ms-settings:windowsupdate`
-- Pressione `Enter`
-- Clique em `Verificar atualizações`
+  Abra a atualização do Windows:
+  - Pressione `Windows` + `R`
+  - Digite `ms-settings:windowsupdate`
+  - Pressione `Enter`
+  - Clique em `Verificar atualizações`
 
-:heavy_check_mark: Se você vir uma marca de seleção verde e a mensagem "Você está atualizado", você está pronto para prosseguir :+1:
+  :heavy_check_mark: Se você vir uma marca de seleção verde e a mensagem "Você está atualizado", você está pronto para prosseguir :+1:
 
-:warning: Se você tiver um ponto de exclamação vermelho e a mensagem "Atualização disponível", instale-os e repita o processo até que apareça que você está atualizado :loop:
+  :warning: Se você tiver um ponto de exclamação vermelho e a mensagem "Atualização disponível", instale-os e repita o processo até que apareça que você está atualizado :loop:
 
-:x: Se você receber uma mensagem de erro sobre o Windows não conseguir aplicar atualizações, **entre em contato com um professor**.
+  :x: Se você receber uma mensagem de erro sobre o Windows não conseguir aplicar atualizações, **entre em contato com um professor**.
 
-<details>
-   <summary>Ative o Windows Update Service para corrigir atualizações</summary>
+  <details>
+    <summary>Ative o Windows Update Service para corrigir atualizações</summary>
 
-   Alguns antivírus e softwares desativam o serviço de atualização de que precisamos, resultando no erro que você vê. Vamos consertar isso!
-   - Pressione `Windows` + `R`
-   - Digite `services.msc`
-   - Pressione `Enter`
-   - Clique duas vezes em `Serviço de atualização do Windows`
-   - Defina sua `Inicialização` para `Automático`
-   - Clique em `Iniciar`
-   - Clique em `Ok`
-   Então vamos tentar as atualizações novamente!
-</details>
-
-
-Verifique o Número da versão:
-
-- Pressione `Windows` + `R`
-- Digite `winver`
-- Pressione `Enter`
+    Alguns antivírus e softwares desativam o serviço de atualização de que precisamos, resultando no erro que você vê. Vamos consertar isso!
+    - Pressione `Windows` + `R`
+    - Digite `services.msc`
+    - Pressione `Enter`
+    - Clique duas vezes em `Serviço de atualização do Windows`
+    - Defina sua `Inicialização` para `Automático`
+    - Clique em `Iniciar`
+    - Clique em `Ok`
+    Então vamos tentar as atualizações novamente!
+  </details>
 
 
-:heavy_check_mark: Se disser pelo menos `2004`, você está pronto :+1:
+  Verifique o Número da versão:
 
-:x: Se estiver abaixo de `22004`, por favor **entre em contato com um professor**.
+  - Pressione `Windows` + `R`
+  - Digite `winver`
+  - Pressione `Enter`
 
-</details>
+
+  :heavy_check_mark: Se disser pelo menos `2004`, você está pronto :+1:
+
+  :x: Se estiver abaixo de `22004`, por favor **entre em contato com um professor**.
+
+  </details>
 
 
 ## Virtualização

--- a/windows.pt.md
+++ b/windows.pt.md
@@ -66,25 +66,14 @@ Para verificar sua versão do Windows:
 - Digite `winver`
 - Pressione `Enter`
 
-:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10 ou Windows 11** você está pronto para prosseguir :+1:
+:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 11** você está pronto para prosseguir :+1:
 
-:x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar para o Windows 10 primeiro :point_down:
+:heavy_check_mark: Se as primeiras palavras desta janela forem **Windows 10**, verifique o **Número da versão**::
+
+:x: Caso contrário, você não poderá prosseguir com esta configuração. Você precisa atualizar.
 
 <details>
-   <summary>Atualizar para o Windows 10</summary>
-
-   - Baixe o Windows 10 da [Microsoft](https://www.microsoft.com/software-download/windows10ISO)
-   - Instale-o. Deve demorar cerca de uma hora, mas isso depende do seu computador.
-   - Quando a instalação terminar, execute os comandos acima :point_up: para verificar se você agora tem o **Windows 10**.
-</details>
-
-:information_source: [A atualização do Windows 11 está sendo lançada agora](https://www.microsoft.com/en-us/windows/get-windows-11), o que significa que ela pode ou não estar disponível para o seu computador ainda .
-
-:warning: **Se você tiver o Windows 10 instalado, não será necessário atualizar para o Windows 11 para prosseguir com esta configuração**.
-
-### Ultimas atualizações
-
-Quando tiver certeza de que está usando o Windows 10 ou 11, você precisará instalar todas as atualizações mais recentes.
+   <summary>Ultimas atualizações</summary>
 
 Abra a atualização do Windows:
 - Pressione `Windows` + `R`
@@ -112,19 +101,19 @@ Abra a atualização do Windows:
    Então vamos tentar as atualizações novamente!
 </details>
 
-### Versão mínima
 
-Algumas das ferramentas que precisamos instalar foram lançadas com a versão `1903` **ou superior** do Windows 10, então precisamos ter certeza de que você tem pelo menos esta.
+Verifique o Número da versão:
 
 - Pressione `Windows` + `R`
 - Digite `winver`
 - Pressione `Enter`
 
-Verifique o **Número da versão**:
 
-:heavy_check_mark: Se disser pelo menos `1903`, você está pronto :+1:
+:heavy_check_mark: Se disser pelo menos `2004`, você está pronto :+1:
 
-:x: Se estiver abaixo de `1903`, por favor **entre em contato com um professor**.
+:x: Se estiver abaixo de `22004`, por favor **entre em contato com um professor**.
+
+</details>
 
 
 ## Virtualização
@@ -170,21 +159,17 @@ Para muitos computadores, este já é o caso. Vamos checar:
 
 WSL é o ambiente de desenvolvimento que usamos para executar o Ubuntu. Você pode aprender mais sobre WSL [aqui](https://docs.microsoft.com/en-us/windows/wsl/faq).
 
-:information_source: As instruções a seguir dependem da sua versão do Windows. Por favor, execute apenas as instruções correspondentes à sua versão :point_down:
+Instalaremos o WSL 2 e o Ubuntu em um comando através do Windows Command Prompt.
 
-### Windows 11
-
-Se você estiver executando o Windows 11, instalaremos o WSL 2 e o Ubuntu em um comando através do Terminal do Windows.
-
-:warning: Nas instruções a seguir, esteja ciente do pressionamento de tecla `Ctrl` + `Shift` + `Enter` para executar o **Terminal Windows** com privilégios de administrador em vez de apenas clicar em `Ok` ou pressionar `Enter` .
+:warning: Nas instruções a seguir, esteja ciente do pressionamento de tecla `Ctrl` + `Shift` + `Enter` para executar o **Windows Command Prompt** com privilégios de administrador em vez de apenas clicar em `Ok` ou pressionar `Enter` .
 
 - Pressione `Windows` + `R`
-- Digite `wt`
+- Digite `cmd`
 - Pressione **`Ctrl` + `Shift` + `Enter`**
 
 :warning: Você pode ter que aceitar a confirmação do UAC sobre a elevação de privilégio.
 
-Uma janela de terminal azul aparecerá:
+Uma janela de terminal aparecerá:
 - Copie o seguinte comando (`Ctrl` + `C`)
 - Cole-o na janela do terminal (`Ctrl` + `V` ou clicando com o botão direito na janela)
 - Execute-o pressionando `Enter`
@@ -197,11 +182,10 @@ wsl --install
 
 :x: Se você encontrar uma mensagem de erro (ou se vir algum texto em vermelho na janela), por favor **entre em contato com um professor**
 
-### Windows 10
+<details>
+<summary>Solução de problemas para Windows 10 (apenas se necessário, consulte um professor)</summary>
 
-#### Instale o WSL 1
-
-Se você estiver executando o Windows 10, primeiro instalaremos o WSL 1 por meio do Terminal PowerShell.
+#### Para Windows 10 < 2004: instale o WSL 1 primeiro
 
 :warning: Nas instruções a seguir, esteja ciente do pressionamento de tecla `Ctrl` + `Shift` + `Enter` para executar o **Windows PowerShell** com privilégios de administrador em vez de apenas clicar em `Ok` ou pressionar `Enter` .
 
@@ -232,7 +216,7 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 :x: Se você encontrar uma mensagem de erro (ou se vir algum texto em vermelho na janela), por favor **entre em contato com um professor**
 
-#### Atualizar para WSL 2
+#### Para Windows 10 com WSL 1: Atualizar para WSL 2
 
 Se você estiver executando o Windows 10, atualizaremos o WSL para a versão 2.
 
@@ -250,7 +234,7 @@ Assim que o computador for reiniciado, precisamos baixar o instalador WSL2.
 
 :x: Se você encontrar o erro "Esta atualização se aplica apenas a máquinas com o subsistema Windows para Linux", **clique com o botão direito** no programa e selecione `uninstall`; você poderá instalá-lo normalmente desta vez.
 
-#### Torne o WSL 2 o subsistema Windows padrão para Linux
+#### Para Windows 10 com WSL 1: Torne o WSL 2 o subsistema Windows padrão para Linux
 
 Se você estiver executando o Windows 10, definiremos a versão padrão do WSL como 2.
 
@@ -283,18 +267,19 @@ wsl --set-default-version 2
    :information_source: Se você estiver executando o Windows 10 **Home edition**, o recurso Hyper-V não estará disponível para o seu sistema operacional. Não bloqueia e você ainda pode continuar seguindo as instruções abaixo :ok_hand:
 </details>
 
+</details>
+
 
 ## Ubuntu
 
 ### Instalação
 
-:information_source: As instruções a seguir dependem da sua versão do Windows. Por favor, execute apenas as instruções correspondentes à sua versão :point_down:
+Após reiniciar o computador, você deverá ver uma janela de terminal informando que o WSL está retomando o processo de instalação do Ubuntu. Quando terminar, o Ubuntu será lançado.
 
-#### Windows 11
+<details>
+<summary>Solução de problemas para Windows 10 (apenas se necessário, consulte um TA)</summary>
 
-Se você estiver executando o Windows 11, após reiniciar o computador, você deverá ver uma janela de terminal informando que o WSL está retomando o processo de instalação do Ubuntu. Quando terminar, o Ubuntu será lançado.
-
-#### Windows 10
+Se a instalação do Ubuntu não foi retomada, tente novamente: abra o Powershell ou o Prompt de Comando e execute `wsl --install` novamente.
 
 Se você estiver executando o Windows 10, vamos instalar o Ubuntu através da Microsoft Store:
 
@@ -382,6 +367,23 @@ wsl -l -v
    :x: Se a conversão ainda não funcionar, por favor **entre em contato com um professor**.
 </details>
 
+Agora você pode fechar esta janela do terminal.
+
+</details>
+
+### Check your username
+
+Type this in the Ubuntu terminal:
+
+```bash
+whoami
+```
+
+It should return the username you chose before.
+
+:x: It if says `root`, **contact a TA** before continuing!
+
+
 ### Verifique a localidade
 
 A localidade é um mecanismo que permite personalizar programas de acordo com seu idioma e país.
@@ -411,8 +413,6 @@ sudo apt-get update
 sudo apt-get install language-pack-en language-pack-en-base manpages
 ```
 </details>
-
-Agora você pode fechar esta janela do terminal.
 
 
 ## Visual Studio Code
@@ -463,7 +463,10 @@ code .
 
 Se você estiver executando o Windows 11, o Terminal do Windows já está instalado e você pode prosseguir para a próxima seção :point_down:
 
-Se você estiver executando o Windows 10, vamos instalar o Windows Terminal, um terminal realmente moderno:
+Se você estiver executando o Windows 10, vamos instalar o Windows Terminal, um terminal realmente moderno.
+
+<details>
+<summary><strong>Windows 10</strong>: Instalar Windows Terminal</summary>
 
 - Clique em `Iniciar`
 - Digite `Microsoft Store`
@@ -487,6 +490,8 @@ Se você estiver executando o Windows 10, vamos instalar o Windows Terminal, um 
 </details>
 
 Assim que a instalação for concluída, o botão `Instalar` se torna um botão `Iniciar`: clique nele.
+
+</details>
 
 ### Ubuntu como terminal padrão
 


### PR DESCRIPTION
Starting from Windows 10 2004 (May 2020 Update), WSL 2 is the default version of WSL. The instructions for installing WSL 2 are now the same for both Windows 10 and Windows 11.

Adapted the instructions as such, to have a common installation process.

This will:
- make the setup easier for remaining Windows 10 users,
- reduce the  number of cases where Windows 11 users started following the Windows 10 instructions by mistake,
- make it easier to maintain the instructions in the future,
- make it easy to remove the Windows 10 instructions later.

For this we now run `wsl --install` in the Windows Command Prompt (cmd) instead of Windows Terminal (wt, for Windows 11) or PowerShell (for Windows 10).

For troubleshooting reasons, the instructions for Windows 10 < 2004 are kept in details, just in case.

Adapted EN, FR, ES, PT.

Additionally, added a check that students have their proper account and are not on `root`. (Quite common and painful to resolve if only discovered at the end.)