### PR TITLE
Fix Windows Edge browser setup

### DIFF
--- a/_partials/cn/windows_browser.md
+++ b/_partials/cn/windows_browser.md
@@ -71,6 +71,7 @@
 
 
   ```bash
+    echo "export BROWSER=\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'\"" >> ~/.zshrc
   ```
 </details>

--- a/_partials/es/windows_browser.md
+++ b/_partials/es/windows_browser.md
@@ -58,6 +58,7 @@ Para asegurarnos de que puedas interactuar desde la terminal de Ubuntu con el na
   Ejecuta el siguiente comandos:
 
   ```bash
+    echo "export BROWSER=\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'\"" >> ~/.zshrc
   ```
 </details>

--- a/_partials/fr/windows_browser.md
+++ b/_partials/fr/windows_browser.md
@@ -58,7 +58,7 @@ Si tu obtiens une erreur du type `ls: cannot access...`, exécute la commande su
   Exécute la commandes :
 
   ```bash
-    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+    echo "export BROWSER=\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'\"" >> ~/.zshrc
   ```
 </details>

--- a/_partials/pt/windows_browser.md
+++ b/_partials/pt/windows_browser.md
@@ -85,7 +85,7 @@ Execute os seguintes comandos:
    Execute os comandos:
 
   ```bash
-    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+    echo "export BROWSER=\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'\"" >> ~/.zshrc
   ```
 

--- a/_partials/windows_browser.md
+++ b/_partials/windows_browser.md
@@ -85,7 +85,7 @@ Run the following commands:
   Run the commands:
 
   ```bash
-    echo "export BROWSER='\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"'" >> ~/.zshrc
+    echo "export BROWSER=\"/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe\"" >> ~/.zshrc
     echo "export GH_BROWSER=\"'/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'\"" >> ~/.zshrc
   ```
 
@@ -112,4 +112,3 @@ exec zsh
 ```
 
 Do not hesitate to **contact a teacher**.
-


### PR DESCRIPTION
Extra pair of quotes breaks the setup. The browser does not get detected.

Aligning with the other browsers.

ES and CN were missing the browser setting completely.

The $BROWSER is needed in the data-setup, which
uses the web setup partials.