### PR TITLE
Set SSH default in gh auth command

### DIFF
--- a/_partials/cn/gh_cli.md
+++ b/_partials/cn/gh_cli.md
@@ -14,15 +14,15 @@ CLI是[Command-line Interface（命令行界面）](https://baike.baidu.com/item
 gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
-gh会问你几个问题：
+`gh`会问你几个问题：
 
-`Generate a new SSH key to add to your GitHub account?（生成新的SSH密钥，然后添加到Github账号上？）` 敲击回车，让gh帮你生成。
+- `Generate a new SSH key to add to your GitHub account?（生成新的SSH密钥，然后添加到Github账号上？）` 敲击回车，让gh帮你生成。
 
-如果你以前生成过SSH密钥，那你就会看到这个问题`Upload your SSH public key to your GitHub account?（上传公共密钥到Github账户上上吗？）` 上下移动箭头`>`，让它停在你想选的SSH公钥前面，然后敲击回车。
+  如果你以前生成过SSH密钥，那你就会看到这个问题`Upload your SSH public key to your GitHub account?（上传公共密钥到Github账户上上吗？）` 上下移动箭头`>`，让它停在你想选的SSH公钥前面，然后敲击回车。
 
-`Enter a passphrase for your new SSH key (Optional)（输入新的SSH密钥的密码（非必填））`. 输入一个密码，然后写下来或者记住它。这是保护你本地私钥的密码。然后敲击回车。
+- `Enter a passphrase for your new SSH key (Optional)（输入新的SSH密钥的密码（非必填））`. 输入一个密码，然后写下来或者记住它。这是保护你本地私钥的密码。然后敲击回车。
 
-`Title for your SSH key`。你可以把它留在建议的 "GitHub CLI"，按`Enter`。
+- `Title for your SSH key`。你可以把它留在建议的 "GitHub CLI"，按`Enter`。
 
 然后你会看到下面的文字输出：
 

--- a/_partials/cn/gh_cli.md
+++ b/_partials/cn/gh_cli.md
@@ -11,12 +11,10 @@ CLI是[Command-line Interface（命令行界面）](https://baike.baidu.com/item
 :warning: **不要更改下面指令中的`email`**
 
 ```bash
-gh auth login -s 'user:email' -w
+gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
 gh会问你几个问题：
-
-`What is your preferred protocol for Git operations?（你要用什么协议来执行Git操作？）` 让箭头`>`停在`SSH`前面，然后敲击回车。SSH使用SSH密钥来登陆用户，而不是用用户名和密码。
 
 `Generate a new SSH key to add to your GitHub account?（生成新的SSH密钥，然后添加到Github账号上？）` 敲击回车，让gh帮你生成。
 

--- a/_partials/es/gh_cli.md
+++ b/_partials/es/gh_cli.md
@@ -4,6 +4,8 @@ CLI es una abreviación de [Command-line Interface](https://en.wikipedia.org/wik
 
 En esta sección usaremos [GitHub CLI](https://cli.github.com/) para interactuar directamente con GitHub desde la terminal.
 
+Usaremos la GitHub CLI (`gh`) para conectarnos a GitHub utilizando *SSH*, un protocolo para iniciar la sesión utilizando claves SSH en lugar de la famosa pareja nombre de usuario y contraseña.
+
 Ya debería haberse instalado en tu computadora con los comandos que ejecutaste anteriormente.
 
 Lo primero que hay que hacer para **iniciar sesión** es copiar y pegar el comando siguiente en tu terminal:
@@ -11,12 +13,10 @@ Lo primero que hay que hacer para **iniciar sesión** es copiar y pegar el coman
 :warning: **NO edites el `email`**
 
 ```bash
-gh auth login -s 'user:email' -w
+gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
 gh le hará algunas preguntas:
-
-`What is your preferred protocol for Git operations?` Con las flechas, elige `SSH` y presiona `Enter`. SSH es un protocolo para iniciar la sesión utilizando claves SSH en lugar de la famosa pareja nombre de usuario y contraseña.
 
 `Generate a new SSH key to add to your GitHub account?` Presiona `Enter` para pedirle a gh que genere las claves SSH por ti.
 

--- a/_partials/es/gh_cli.md
+++ b/_partials/es/gh_cli.md
@@ -16,15 +16,15 @@ Lo primero que hay que hacer para **iniciar sesión** es copiar y pegar el coman
 gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
-gh le hará algunas preguntas:
+`gh` le hará algunas preguntas:
 
-`Generate a new SSH key to add to your GitHub account?` Presiona `Enter` para pedirle a gh que genere las claves SSH por ti.
+- `Generate a new SSH key to add to your GitHub account?` Presiona `Enter` para pedirle a gh que genere las claves SSH por ti.
 
-Si ya tienes claves SSH, verás en su lugar `Upload your SSH public key to your GitHub account?`Con las flechas, selecciona la ruta de tu archivo de clave pública y pulsa `Intro`.
+  Si ya tienes claves SSH, verás en su lugar `Upload your SSH public key to your GitHub account?`Con las flechas, selecciona la ruta de tu archivo de clave pública y pulsa `Intro`.
 
-`Enter a passphrase for your new SSH key (Optional)`. Pon algo que quieras y que recuerdes. Es una contraseña para proteger tu private key que está almacenada en tu disco duro. Luego presiona `Enter`.
+- `Enter a passphrase for your new SSH key (Optional)`. Pon algo que quieras y que recuerdes. Es una contraseña para proteger tu private key que está almacenada en tu disco duro. Luego presiona `Enter`.
 
-`Title for your SSH key`. Puede dejarlo en la propuesta "GitHub CLI", presiona `Enter`.
+- `Title for your SSH key`. Puede dejarlo en la propuesta "GitHub CLI", presiona `Enter`.
 
 Obtendrás el siguiente resultado:
 

--- a/_partials/fr/gh_cli.md
+++ b/_partials/fr/gh_cli.md
@@ -16,15 +16,15 @@ Pour **te connecter**, commence par copier-coller la commande suivante dans ton 
 gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
-gh va te poser quelques questions :
+`gh` va te poser quelques questions :
 
-`Generate a new SSH key to add to your GitHub account?` Appuie sur `Enter` pour demander à gh de générer les clés SSH pour toi.
+- `Generate a new SSH key to add to your GitHub account?` Appuie sur `Enter` pour demander à gh de générer les clés SSH pour toi.
 
-Si tu as déjà des clés SSH, tu verras à la place `Upload your SSH public key to your GitHub account?` Avec les flèches, sélectionne le chemain de ta clé publique et appuie sur `Enter`.
+  Si tu as déjà des clés SSH, tu verras à la place `Upload your SSH public key to your GitHub account?` Avec les flèches, sélectionne le chemain de ta clé publique et appuie sur `Enter`.
 
-`Enter a passphrase for your new SSH key (Optional)`. Saisis un mot de passe dont tu te souviendras. Ce mot de passe sert à protéger ta clé privée enregistrée sur ton disque sur. Ensuite, appuie sur `Enter`.
+- `Enter a passphrase for your new SSH key (Optional)`. Saisis un mot de passe dont tu te souviendras. Ce mot de passe sert à protéger ta clé privée enregistrée sur ton disque sur. Ensuite, appuie sur `Enter`.
 
-`Title for your SSH key`. Tu peux laisser ce qui est proposé par défaut, à savoir "GitHub CLI", appuie sur `Enter`.
+- `Title for your SSH key`. Tu peux laisser ce qui est proposé par défaut, à savoir "GitHub CLI", appuie sur `Enter`.
 
 Tu obtiendras le résultat suivant :
 

--- a/_partials/fr/gh_cli.md
+++ b/_partials/fr/gh_cli.md
@@ -4,6 +4,8 @@ CLI est l’acronyme de [Command-line Interface](https://en.wikipedia.org/wiki/C
 
 Dans cette section, tu vas installer [GitHub CLI](https://cli.github.com/) pour interagir avec GitHub directement depuis le terminal.
 
+Nous allons utiliser GitHub CLI (`gh`) pour nous connecter à GitHub en utilisant *SSH*, un protocole pour s'authentifier en utilisant des clés SSH au lieu de la fameuse paire nom d'utilisateur et mot de passe.
+
 Elle doit déjà être installée sur ton ordinateur grâce aux commandes précédentes.
 
 Pour **te connecter**, commence par copier-coller la commande suivante dans ton terminal :
@@ -11,12 +13,10 @@ Pour **te connecter**, commence par copier-coller la commande suivante dans ton 
 :warning: **NE modifie PAS `email`**
 
 ```bash
-gh auth login -s 'user:email' -w
+gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
 gh va te poser quelques questions :
-
-`What is your preferred protocol for Git operations?` Avec les flèches, choisis `SSH` et appuie sur `Enter`. SSH est un protocole pour s'authentifier en utilisant des clés SSH au lieu de la fameuse paire nom d'utilisateur et mot de passe.
 
 `Generate a new SSH key to add to your GitHub account?` Appuie sur `Enter` pour demander à gh de générer les clés SSH pour toi.
 

--- a/_partials/gh_cli.md
+++ b/_partials/gh_cli.md
@@ -6,17 +6,17 @@ In this section, we will use [GitHub CLI](https://cli.github.com/) to interact w
 
 It should already be installed on your computer from the previous commands.
 
+We will use the GitHub CLI (`gh`) to connect to GitHub using *SSH*, a protocol to log in using SSH keys instead of the well known username/password pair.
+
 First in order to **login**, copy-paste the following command in your terminal:
 
 :warning: **DO NOT edit the `email`**
 
 ```bash
-gh auth login -s 'user:email' -w
+gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
 gh will ask you few questions:
-
-`What is your preferred protocol for Git operations?` With the arrows, choose `SSH` and press `Enter`. SSH is a protocol to log in using SSH keys instead of the well known username/password pair.
 
 `Generate a new SSH key to add to your GitHub account?` Press `Enter` to ask gh to generate the SSH keys for you.
 

--- a/_partials/gh_cli.md
+++ b/_partials/gh_cli.md
@@ -16,15 +16,15 @@ First in order to **login**, copy-paste the following command in your terminal:
 gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
-gh will ask you few questions:
+`gh` will ask you few questions:
 
-`Generate a new SSH key to add to your GitHub account?` Press `Enter` to ask gh to generate the SSH keys for you.
+- `Generate a new SSH key to add to your GitHub account?` Press `Enter` to ask gh to generate the SSH keys for you.
 
-If you already have SSH keys, you will see instead `Upload your SSH public key to your GitHub account?` With the arrows, select your public key file path and press `Enter`.
+  If you already have SSH keys, you will see instead `Upload your SSH public key to your GitHub account?` With the arrows, select your public key file path and press `Enter`.
 
-`Enter a passphrase for your new SSH key (Optional)`. Type something you want and that you'll remember. It's a password to protect your private key stored on your hard drive. Then press `Enter`.
+- `Enter a passphrase for your new SSH key (Optional)`. Type something you want and that you'll remember. It's a password to protect your private key stored on your hard drive. Then press `Enter`.
 
-`Title for your SSH key`. You can leave it at the proposed "GitHub CLI", press `Enter`.
+- `Title for your SSH key`. You can leave it at the proposed "GitHub CLI", press `Enter`.
 
 You will then get the following output:
 

--- a/_partials/pt/gh_cli.md
+++ b/_partials/pt/gh_cli.md
@@ -4,6 +4,9 @@ CLI é o acrônimo de [Interface de linha de comando](https://en.wikipedia.org/w
 
 Nesta seção, usaremos [GitHub CLI](https://cli.github.com/) para interagir com o GitHub diretamente do terminal.
 
+Usaremos o GitHub CLI (`gh`) para conectar ao GitHub usando *SSH*, um protocolo para fazer login usando chaves SSH em vez do conhecido par nome de usuário/senha.
+
+
 Ele já deve estar instalado no seu computador a partir dos comandos anteriores.
 
 Primeiro, para **fazer login**, copie e cole o seguinte comando em seu terminal:
@@ -11,12 +14,10 @@ Primeiro, para **fazer login**, copie e cole o seguinte comando em seu terminal:
 :warning: **NÃO edite o `email`**
 
 ```bash
-gh auth login -s 'user:email' -w
+gh auth login -s 'user:email' -w --git-protocol ssh
 ```
 
 `gh` fará algumas perguntas:
-
-`What is your preferred protocol for Git operations?` Com as setas, escolha `SSH` e pressione `Enter`. SSH é um protocolo para fazer login usando chaves SSH em vez do conhecido par nome de usuário/senha.
 
 `Generate a new SSH key to add to your GitHub account?` Pressione `Enter` para pedir ao gh para gerar as chaves SSH para você.
 

--- a/_partials/pt/gh_cli.md
+++ b/_partials/pt/gh_cli.md
@@ -19,13 +19,13 @@ gh auth login -s 'user:email' -w --git-protocol ssh
 
 `gh` fará algumas perguntas:
 
-`Generate a new SSH key to add to your GitHub account?` Pressione `Enter` para pedir ao gh para gerar as chaves SSH para você.
+- `Generate a new SSH key to add to your GitHub account?` Pressione `Enter` para pedir ao gh para gerar as chaves SSH para você.
 
-Se você já possui chaves SSH, verá `Upload your SSH public key to your GitHub account?` Com as setas, selecione o caminho do arquivo de sua chave pública e pressione `Enter`.
+  Se você já possui chaves SSH, verá `Upload your SSH public key to your GitHub account?` Com as setas, selecione o caminho do arquivo de sua chave pública e pressione `Enter`.
 
-`Enter a passphrase for your new SSH key (Optional)`. Digite algo que você deseja e que você lembrará. É uma senha para proteger sua chave privada armazenada no disco rígido. Em seguida, pressione `Enter`.
+- `Enter a passphrase for your new SSH key (Optional)`. Digite algo que você deseja e que você lembrará. É uma senha para proteger sua chave privada armazenada no disco rígido. Em seguida, pressione `Enter`.
 
-`Title for your SSH key`. Você pode deixá-lo no "GitHub CLI" proposto, pressione `Enter`.
+- `Title for your SSH key`. Você pode deixá-lo no "GitHub CLI" proposto, pressione `Enter`.
 
 Você obterá então a seguinte saída:
 


### PR DESCRIPTION
Currently students have to select the protocol in the interactive
questions asked by `gh`. The first option is HTTP, and regularly is
chosen by accident instead of SSH. This remains undetected until late in
the setup, or even later, and then requires several steps (especially if
challenge repos have already been created).

This PR sets the correct protocol in the command, so it no longer
needs to be set in the interactive questions.

This PR also formats the questions asked by `gh` into list form for clarity.